### PR TITLE
Add Size Limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && size-limit"
 	},
 	"files": [
 		"index.js"
@@ -45,6 +45,13 @@
 	"devDependencies": {
 		"ava": "*",
 		"delay": "^2.0.0",
+		"size-limit": "^0.13.2",
 		"xo": "*"
-	}
+	},
+	"size-limit": [
+		{
+			"path": "index.js",
+			"limit": "338 B"
+		}
+	]
 }


### PR DESCRIPTION
Welcome to Bundle Size Optimization society =^_^=. Let’s me introduce you [Size Limit](https://github.com/ai/size-limit) — like a linter, but for file size (feel free to close PR, I just want to show here how the tool works).

Any optimization must use benchmarking and profiling before actual optimization. I think the same rule can be applied to bundle size optimization. We need some sort of benchmark to have every-commit feedback and run this benchmark on the Travis CI to prevent accidentally regression.

For example, in some future PR, somebody could use `process` or `global` in the wrong way, as result, your library size could be increased twice just because of few extra symbols.

This is why I created Size Limit, a tool to have feedback about library size and prevent JS libraries bloat.

Here is production success stories:

* [PostCSS](https://github.com/postcss/postcss) reduced [25% of the size](https://github.com/postcss/postcss/commit/150edaa42f6d7ede73d8c72be9909f0a0f87a70f).
* [Browserslist](https://github.com/ai/browserslist) reduced [25% of the size](https://github.com/ai/browserslist/commit/640b62fa83a20897cae75298a9f2715642531623).
* [EmojiMart](https://github.com/missive/emoji-mart) reduced [20% of the size](https://github.com/missive/emoji-mart/pull/111)
* [nanoid](https://github.com/ai/nanoid) reduced [33% of the size](https://github.com/ai/nanoid/commit/036612e7d6cc5760313a8850a2751a5e95184eab).
* [Logux](https://github.com/logux) reduced [90% of the size](https://github.com/logux/logux-client/commit/62b258e20e1818b23ae39b9c4cd49e2495781e91).

And few articles, [how it works inside](https://evilmartians.com/chronicles/size-limit-make-the-web-lighter).