### PR TITLE
House keeping & type-check event names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.nyc_output
+coverage
 node_modules
 yarn.lock
 /legacy.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.nyc_output
-coverage
 node_modules
 yarn.lock
+.nyc_output
+coverage
 /legacy.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ node_js:
   - '8'
   - '6'
   - '4'
+cache:
+  directories:
+    - $HOME/.npm
+before_install:
+  - npm install --global npm@5.6.0
+  - npm --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ node_js:
   - '8'
   - '6'
   - '4'
-install:
-  - npm install
-  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ cache:
 before_install:
   - npm install --global npm@5.6.0
   - npm --version
+after_success: npx codecov --file=./coverage/lcov.info

--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@
 
 const resolvedPromise = Promise.resolve();
 
+function assertEventName(eventName) {
+	if (typeof eventName !== 'string') {
+		throw new TypeError('eventName must be a string');
+	}
+}
+
 module.exports = class Emittery {
 	constructor() {
 		this._events = new Map();
@@ -17,11 +23,13 @@ module.exports = class Emittery {
 	}
 
 	on(eventName, listener) {
+		assertEventName(eventName);
 		this._getListeners(eventName).add(listener);
 		return this.off.bind(this, eventName, listener);
 	}
 
 	off(eventName, listener) {
+		assertEventName(eventName);
 		if (listener) {
 			this._getListeners(eventName).delete(listener);
 		} else {
@@ -31,6 +39,7 @@ module.exports = class Emittery {
 
 	once(eventName) {
 		return new Promise(resolve => {
+			assertEventName(eventName);
 			const off = this.on(eventName, data => {
 				off();
 				resolve(data);
@@ -39,6 +48,7 @@ module.exports = class Emittery {
 	}
 
 	async emit(eventName, eventData) {
+		assertEventName(eventName);
 		await resolvedPromise;
 		const listeners = [...this._getListeners(eventName)].map(async listener => listener(eventData));
 		const anyListeners = [...this._anyEvents].map(async listener => listener(eventName, eventData));
@@ -46,6 +56,7 @@ module.exports = class Emittery {
 	}
 
 	async emitSerial(eventName, eventData) {
+		assertEventName(eventName);
 		await resolvedPromise;
 
 		/* eslint-disable no-await-in-loop */
@@ -78,8 +89,12 @@ module.exports = class Emittery {
 	}
 
 	listenerCount(eventName) {
-		if (eventName) {
+		if (typeof eventName === 'string') {
 			return this._anyEvents.size + this._getListeners(eventName).size;
+		}
+
+		if (typeof eventName !== 'undefined') {
+			assertEventName(eventName);
 		}
 
 		let count = this._anyEvents.size;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "babel --out-file=legacy.js index.js",
-    "prepack": "npm install && npm run build",
+    "prepublish": "npm run build",
     "test": "xo && ava"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "babel --out-file=legacy.js index.js",
+    "build:watch": "npm run build -- --watch",
     "prepublish": "npm run build",
     "test": "xo && ava"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "nyc": {
-  "reporter": [
+    "reporter": [
       "html",
       "lcov",
       "text"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "babel --out-file=legacy.js index.js",
     "build:watch": "npm run build -- --watch",
     "prepublish": "npm run build",
-    "test": "xo && ava"
+    "test": "xo && nyc ava"
   },
   "files": [
     "index.js",
@@ -52,13 +52,22 @@
     "babel-core": "^6.26.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-es2015-spread": "^6.22.0",
+    "codecov": "^3.0.0",
     "delay": "^2.0.0",
+    "nyc": "^11.3.0",
     "xo": "*"
   },
   "babel": {
     "plugins": [
       "transform-async-to-generator",
       "transform-es2015-spread"
+    ]
+  },
+  "nyc": {
+  "reporter": [
+      "html",
+      "lcov",
+      "text"
     ]
   }
 }

--- a/test/_run.js
+++ b/test/_run.js
@@ -11,6 +11,11 @@ module.exports = Emittery => {
 		t.deepEqual([...emitter._events.get('🦄')], [listener1, listener2]);
 	});
 
+	test('on() - eventName must be a string', t => {
+		const emitter = new Emittery();
+		t.throws(() => emitter.on(42, () => {}), TypeError);
+	});
+
 	test('on() - returns a unsubcribe method', t => {
 		const emitter = new Emittery();
 		const listener = () => {};
@@ -43,6 +48,11 @@ module.exports = Emittery => {
 		t.is(emitter._events.get('🦄').size, 0);
 	});
 
+	test('off() - eventName must be a string', t => {
+		const emitter = new Emittery();
+		t.throws(() => emitter.off(42), TypeError);
+	});
+
 	test('off() - all listeners', t => {
 		const emitter = new Emittery();
 
@@ -60,6 +70,11 @@ module.exports = Emittery => {
 		const promise = emitter.once('🦄');
 		emitter.emit('🦄', fixture);
 		t.is(await promise, fixture);
+	});
+
+	test('once() - eventName must be a string', async t => {
+		const emitter = new Emittery();
+		await t.throws(emitter.once(42), TypeError);
 	});
 
 	test.cb('emit() - one event', t => {
@@ -96,6 +111,11 @@ module.exports = Emittery => {
 		emitter.emit('🦄');
 		emitter.emit('🦄');
 		emitter.emit('🦄');
+	});
+
+	test('emit() - eventName must be a string', async t => {
+		const emitter = new Emittery();
+		await t.throws(emitter.emit(42), TypeError);
 	});
 
 	test.cb('emit() - is async', t => {
@@ -138,6 +158,11 @@ module.exports = Emittery => {
 		emitter.on('🦄', () => listener(5));
 
 		emitter.emitSerial('🦄', 'e');
+	});
+
+	test('emitSerial() - eventName must be a string', async t => {
+		const emitter = new Emittery();
+		await t.throws(emitter.emitSerial(42), TypeError);
 	});
 
 	test.cb('emitSerial() - is async', t => {
@@ -215,5 +240,16 @@ module.exports = Emittery => {
 		t.is(emitter.listenerCount('🦄'), 4);
 		t.is(emitter.listenerCount('🌈'), 3);
 		t.is(emitter.listenerCount(), 5);
+	});
+
+	test('listenerCount() - works with empty eventName strings', t => {
+		const emitter = new Emittery();
+		emitter.on('', () => {});
+		t.is(emitter.listenerCount(''), 1);
+	});
+
+	test('listenerCount() - eventName must be undefined if not a string', t => {
+		const emitter = new Emittery();
+		t.throws(() => emitter.listenerCount(42), TypeError);
 	});
 };

--- a/test/_run.js
+++ b/test/_run.js
@@ -157,11 +157,19 @@ module.exports = Emittery => {
 		t.false(unicorn);
 	});
 
-	test('onAny()', t => {
+	test('onAny()', async t => {
+		t.plan(4);
+
 		const emitter = new Emittery();
-		t.is(emitter._anyEvents.size, 0);
-		emitter.onAny(() => {});
-		t.is(emitter._anyEvents.size, 1);
+		const eventFixture = {foo: true};
+
+		emitter.onAny((eventName, data) => {
+			t.is(eventName, '🦄');
+			t.deepEqual(data, eventFixture);
+		});
+
+		await emitter.emit('🦄', eventFixture);
+		await emitter.emitSerial('🦄', eventFixture);
 	});
 
 	test('offAny()', t => {


### PR DESCRIPTION
Apologies for the lead up:

* I got the npm scripts wrong for the builds, I think, but I'm still confused about it
* It's nice to have a `build:watch` script so `legacy.js` gets rebuilt and retested with `ava --watch`
* I've hooked up code coverage
* This is nicest with `npx codecov` but then we need to make sure we've got npm@5 everywhere
* The code paths firing `onAny()` listeners weren't actually tested

And then finally the last commit type-checks event names in all functions they're used, with a special case in `listenerCount()` to allow the empty string as an event name.

Fixes #12.