### PR TITLE
Revisit `.off()` and `.clear()`

### DIFF
--- a/Emittery.d.ts
+++ b/Emittery.d.ts
@@ -13,11 +13,8 @@ declare class Emittery {
 
 		/**
 		 * Remove an event subscription.
-		 *
-		 * If you don't pass in a `listener`, it will remove all listeners for that
-		 * event.
 		 */
-		off(eventName: string, listener?: (eventData?: any) => any): void;
+		off(eventName: string, listener: (eventData?: any) => any): void;
 
 		/**
 		 * Subscribe to an event only once. It will be unsubscribed after the first
@@ -64,10 +61,8 @@ declare class Emittery {
 
 		/**
 		 * Remove an `onAny` subscription.
-		 *
-		 * If you don't pass in a `listener`, it will remove all `onAny` subscriptions.
 		 */
-		offAny(listener?: (eventName: string, eventData?: any) => any): void;
+		offAny(listener: (eventName: string, eventData?: any) => any): void;
 
 		/**
 		 * Clear all event listeners on the instance.

--- a/Emittery.d.ts
+++ b/Emittery.d.ts
@@ -12,11 +12,11 @@ declare class Emittery {
 		on(eventName: string, listener: (eventData?: any) => any): Emittery.UnsubscribeFn;
 
 		/**
-		* Remove an event subscription.
-		*
-		* If you don't pass in a `listener`, it will remove all listeners for that
-		* event.
-		*/
+		 * Remove an event subscription.
+		 *
+		 * If you don't pass in a `listener`, it will remove all listeners for that
+		 * event.
+		 */
 		off(eventName: string, listener?: (eventData?: any) => any): void;
 
 		/**
@@ -63,9 +63,9 @@ declare class Emittery {
 		onAny(listener: (eventName: string, eventData?: any) => any): Emittery.UnsubscribeFn;
 
 		/**
-		Remove an `onAny` subscription.
-
-		If you don't pass in a `listener`, it will remove all `onAny` subscriptions.
+		 * Remove an `onAny` subscription.
+		 *
+		 * If you don't pass in a `listener`, it will remove all `onAny` subscriptions.
 		 */
 		offAny(listener?: (eventName: string, eventData?: any) => any): void;
 

--- a/Emittery.d.ts
+++ b/Emittery.d.ts
@@ -67,7 +67,7 @@ declare class Emittery {
 		/**
 		 * Clear all event listeners on the instance.
 		 */
-		clear(): void;
+		clearListeners(): void;
 
 		/**
 		 * The number of listeners for the `eventName` or all events if not

--- a/Emittery.d.ts
+++ b/Emittery.d.ts
@@ -66,8 +66,10 @@ declare class Emittery {
 
 		/**
 		 * Clear all event listeners on the instance.
+		 *
+		 * If `eventName` is given, only the listeners for that event are cleared.
 		 */
-		clearListeners(): void;
+		clearListeners(eventName?: string): void;
 
 		/**
 		 * The number of listeners for the `eventName` or all events if not

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class Emittery {
 		anyMap.get(this).delete(listener);
 	}
 
-	clear() {
+	clearListeners() {
 		anyMap.get(this).clear();
 		eventsMap.get(this).clear();
 	}

--- a/index.js
+++ b/index.js
@@ -88,9 +88,13 @@ class Emittery {
 		anyMap.get(this).delete(listener);
 	}
 
-	clearListeners() {
-		anyMap.get(this).clear();
-		eventsMap.get(this).clear();
+	clearListeners(eventName) {
+		if (typeof eventName === 'string') {
+			getListeners(this, eventName).clear();
+		} else {
+			anyMap.get(this).clear();
+			eventsMap.get(this).clear();
+		}
 	}
 
 	listenerCount(eventName) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ function assertEventName(eventName) {
 	}
 }
 
+function assertListener(listener) {
+	if (typeof listener !== 'function') {
+		throw new TypeError('listener must be a function');
+	}
+}
+
 function getListeners(instance, eventName) {
 	const events = eventsMap.get(instance);
 	if (!events.has(eventName)) {
@@ -33,11 +39,8 @@ class Emittery {
 
 	off(eventName, listener) {
 		assertEventName(eventName);
-		if (listener) {
-			getListeners(this, eventName).delete(listener);
-		} else {
-			getListeners(this, eventName).clear();
-		}
+		assertListener(listener);
+		getListeners(this, eventName).delete(listener);
 	}
 
 	once(eventName) {
@@ -79,11 +82,8 @@ class Emittery {
 	}
 
 	offAny(listener) {
-		if (listener) {
-			anyMap.get(this).delete(listener);
-		} else {
-			anyMap.get(this).clear();
-		}
+		assertListener(listener);
+		anyMap.get(this).delete(listener);
 	}
 
 	clear() {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class Emittery {
 
 	on(eventName, listener) {
 		assertEventName(eventName);
+		assertListener(listener);
 		getListeners(this, eventName).add(listener);
 		return this.off.bind(this, eventName, listener);
 	}
@@ -77,6 +78,7 @@ class Emittery {
 	}
 
 	onAny(listener) {
+		assertListener(listener);
 		anyMap.get(this).add(listener);
 		return this.offAny.bind(this, listener);
 	}

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,8 @@ Remove an `onAny` subscription.
 
 Clear all event listeners on the instance.
 
+If `eventName` is given, only the listeners for that event are cleared.
+
 #### listenerCount([eventName])
 
 The number of listeners for the `eventName` or all events if not specified.

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Returns a method to unsubscribe.
 
 Remove an `onAny` subscription.
 
-#### clear()
+#### clearListeners()
 
 Clear all event listeners on the instance.
 

--- a/readme.md
+++ b/readme.md
@@ -49,11 +49,9 @@ Using the same listener multiple times for the same event will result in only on
 
 ##### listener(data)
 
-#### off(eventName, [listener])
+#### off(eventName, listener)
 
 Remove an event subscription.
-
-If you don't pass in a `listener`, it will remove all listeners for that event.
 
 ##### listener(data)
 
@@ -92,11 +90,9 @@ Returns a method to unsubscribe.
 
 ##### listener(eventName, data)
 
-#### offAny([listener])
+#### offAny(listener)
 
 Remove an `onAny` subscription.
-
-If you don't pass in a `listener`, it will remove all `onAny` subscriptions.
 
 #### clear()
 

--- a/test/_run.js
+++ b/test/_run.js
@@ -228,7 +228,7 @@ module.exports = Emittery => {
 		t.throws(() => emitter.offAny(), TypeError);
 	});
 
-	test('clear()', async t => {
+	test('clearListeners()', async t => {
 		const emitter = new Emittery();
 		const calls = [];
 		emitter.on('🦄', () => calls.push('🦄1'));
@@ -239,7 +239,7 @@ module.exports = Emittery => {
 		await emitter.emit('🦄');
 		await emitter.emit('🌈');
 		t.deepEqual(calls, ['🦄1', '🦄2', 'any1', 'any2', '🌈', 'any1', 'any2']);
-		emitter.clear();
+		emitter.clearListeners();
 		await emitter.emit('🦄');
 		await emitter.emit('🌈');
 		t.deepEqual(calls, ['🦄1', '🦄2', 'any1', 'any2', '🌈', 'any1', 'any2']);

--- a/test/_run.js
+++ b/test/_run.js
@@ -245,6 +245,23 @@ module.exports = Emittery => {
 		t.deepEqual(calls, ['🦄1', '🦄2', 'any1', 'any2', '🌈', 'any1', 'any2']);
 	});
 
+	test('clearListeners() - with event name', async t => {
+		const emitter = new Emittery();
+		const calls = [];
+		emitter.on('🦄', () => calls.push('🦄1'));
+		emitter.on('🌈', () => calls.push('🌈'));
+		emitter.on('🦄', () => calls.push('🦄2'));
+		emitter.onAny(() => calls.push('any1'));
+		emitter.onAny(() => calls.push('any2'));
+		await emitter.emit('🦄');
+		await emitter.emit('🌈');
+		t.deepEqual(calls, ['🦄1', '🦄2', 'any1', 'any2', '🌈', 'any1', 'any2']);
+		emitter.clearListeners('🦄');
+		await emitter.emit('🦄');
+		await emitter.emit('🌈');
+		t.deepEqual(calls, ['🦄1', '🦄2', 'any1', 'any2', '🌈', 'any1', 'any2', 'any1', 'any2', '🌈', 'any1', 'any2']);
+	});
+
 	test('listenerCount()', t => {
 		const emitter = new Emittery();
 		emitter.on('🦄', () => {});

--- a/test/_run.js
+++ b/test/_run.js
@@ -18,6 +18,11 @@ module.exports = Emittery => {
 		t.throws(() => emitter.on(42, () => {}), TypeError);
 	});
 
+	test('on() - must have a listener', t => {
+		const emitter = new Emittery();
+		t.throws(() => emitter.on('🦄'), TypeError);
+	});
+
 	test('on() - returns a unsubcribe method', async t => {
 		const emitter = new Emittery();
 		const calls = [];
@@ -199,6 +204,11 @@ module.exports = Emittery => {
 
 		await emitter.emit('🦄', eventFixture);
 		await emitter.emitSerial('🦄', eventFixture);
+	});
+
+	test('onAny() - must have a listener', t => {
+		const emitter = new Emittery();
+		t.throws(() => emitter.onAny(), TypeError);
 	});
 
 	test('offAny()', async t => {

--- a/test/_run.js
+++ b/test/_run.js
@@ -63,18 +63,9 @@ module.exports = Emittery => {
 		t.throws(() => emitter.off(42), TypeError);
 	});
 
-	test('off() - all listeners', async t => {
+	test('off() - no listener', t => {
 		const emitter = new Emittery();
-		const calls = [];
-
-		emitter.on('🦄', () => calls.push(1));
-		emitter.on('🦄', () => calls.push(2));
-		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 2]);
-
-		emitter.off('🦄');
-		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 2]);
+		t.throws(() => emitter.off('🦄'), TypeError);
 	});
 
 	test('once()', async t => {
@@ -222,17 +213,9 @@ module.exports = Emittery => {
 		t.deepEqual(calls, [1]);
 	});
 
-	test('offAny() - all listeners', async t => {
+	test('offAny() - no listener', t => {
 		const emitter = new Emittery();
-		const calls = [];
-		emitter.onAny(() => calls.push(1));
-		emitter.onAny(() => calls.push(2));
-		emitter.onAny(() => calls.push(3));
-		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 2, 3]);
-		emitter.offAny();
-		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 2, 3]);
+		t.throws(() => emitter.offAny(), TypeError);
 	});
 
 	test('clear()', async t => {


### PR DESCRIPTION
Fixes #22. `on()`, `onAny()`, `off()` and `offAny()` now **must** be called with a `listener` function. You can no longer remove all listeners for a particular event. Renamed `clear()` to `clearListeners()` which is, well, clearer if `Emittery` is subclassed.

I discussed more advanced "disposal" behaviors in #22 but I think this is sufficient.

---

PR against #24 as to avoid having to resolve the inevitable merge conflicts.
