### PR TITLE
Gather listeners before calling them

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,22 +52,28 @@ class Emittery {
 
 	async emit(eventName, eventData) {
 		assertEventName(eventName);
+		const listeners = [...getListeners(this, eventName)];
+		const anyListeners = [...anyMap.get(this)];
+
 		await resolvedPromise;
-		const listeners = [...getListeners(this, eventName)].map(async listener => listener(eventData));
-		const anyListeners = [...anyMap.get(this)].map(async listener => listener(eventName, eventData));
-		return Promise.all([...listeners, ...anyListeners]);
+		return Promise.all([
+			...listeners.map(async listener => listener(eventData)),
+			...anyListeners.map(async listener => listener(eventName, eventData))
+		]);
 	}
 
 	async emitSerial(eventName, eventData) {
 		assertEventName(eventName);
-		await resolvedPromise;
+		const listeners = [...getListeners(this, eventName)];
+		const anyListeners = [...anyMap.get(this)];
 
+		await resolvedPromise;
 		/* eslint-disable no-await-in-loop */
-		for (const listener of getListeners(this, eventName)) {
+		for (const listener of listeners) {
 			await listener(eventData);
 		}
 
-		for (const listener of anyMap.get(this)) {
+		for (const listener of anyListeners) {
 			await listener(eventName, eventData);
 		}
 		/* eslint-enable no-await-in-loop */

--- a/test/_run.js
+++ b/test/_run.js
@@ -148,6 +148,45 @@ module.exports = Emittery => {
 		t.false(unicorn);
 	});
 
+	test('emit() - calls listeners subscribed when emit() was invoked', async t => {
+		const emitter = new Emittery();
+		const calls = [];
+		const off1 = emitter.on('🦄', () => calls.push(1));
+		const p = emitter.emit('🦄');
+		emitter.on('🦄', () => calls.push(2));
+		await p;
+		t.deepEqual(calls, [1]);
+
+		const off3 = emitter.on('🦄', () => {
+			calls.push(3);
+			off1();
+			emitter.on('🦄', () => calls.push(4));
+		});
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3]);
+		off3();
+
+		const off5 = emitter.on('🦄', () => {
+			calls.push(5);
+			emitter.onAny(() => calls.push(6));
+		});
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5]);
+		off5();
+
+		let off8 = null;
+		emitter.onAny(() => {
+			calls.push(7);
+			off8();
+		});
+		off8 = emitter.onAny(() => calls.push(8));
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8]);
+
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8, 2, 4, 6, 7]);
+	});
+
 	test.cb('emitSerial()', t => {
 		t.plan(1);
 
@@ -193,6 +232,45 @@ module.exports = Emittery => {
 		emitter.emitSerial('🦄');
 
 		t.false(unicorn);
+	});
+
+	test('emitSerial() - calls listeners subscribed when emitSerial() was invoked', async t => {
+		const emitter = new Emittery();
+		const calls = [];
+		const off1 = emitter.on('🦄', () => calls.push(1));
+		const p = emitter.emitSerial('🦄');
+		emitter.on('🦄', () => calls.push(2));
+		await p;
+		t.deepEqual(calls, [1]);
+
+		const off3 = emitter.on('🦄', () => {
+			calls.push(3);
+			off1();
+			emitter.on('🦄', () => calls.push(4));
+		});
+		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3]);
+		off3();
+
+		const off5 = emitter.on('🦄', () => {
+			calls.push(5);
+			emitter.onAny(() => calls.push(6));
+		});
+		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5]);
+		off5();
+
+		let off8 = null;
+		emitter.onAny(() => {
+			calls.push(7);
+			off8();
+		});
+		off8 = emitter.onAny(() => calls.push(8));
+		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8]);
+
+		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8, 2, 4, 6, 7]);
 	});
 
 	test('onAny()', async t => {


### PR DESCRIPTION
This ensures that when `emit()` or `emitSerial()` are invoked, only listeners added *before* this invocation are called. This is necessary since emitting results in listeners being called asynchronously.

Listeners may add new event subscriptions. These shouldn't be called for an event that is currently being emitted.

Previously this behavior was only guaranteed in `emit()`, for event listeners adding new event subscriptions, and any listeners adding new any subscriptions, but not for event listeners adding new any subscriptions. `emitSerial()` would allow any mutation, including removal.

---

PR against #24 as to avoid having to resolve the inevitable merge conflicts.