### PR TITLE
Never invoke listeners after removal, document scheduling details, fix examples

### DIFF
--- a/examples/emit.js
+++ b/examples/emit.js
@@ -6,12 +6,12 @@ const Emittery = require('..');
 
 const myEmitter = new Emittery();
 
-// Emit event in next tick
-myEmitter.emit('event');
-
 // Register listener
 myEmitter.on('event', () => console.log('an event occurred!'));
 myEmitter.onAny(eventName => console.log('"%s" event occurred!', eventName));
+
+// Emit event in next tick
+myEmitter.emit('event');
 
 // Prints:
 // 		an event occurred!

--- a/examples/emitonce.js
+++ b/examples/emitonce.js
@@ -6,13 +6,13 @@ const Emittery = require('..');
 
 const myEmitter = new Emittery();
 
-// Emit events in next tick
-myEmitter.emit('event', 1);
-myEmitter.emit('event', 2);
-
 // Register listener for only the one event
 myEmitter.once('event')
 	.then(count => console.log('an event occurred (#%d).', count));
+
+// Emit events in next tick
+myEmitter.emit('event', 1);
+myEmitter.emit('event', 2);
 
 // Prints:
 //		an event occurred (#1).

--- a/examples/eventdata.js
+++ b/examples/eventdata.js
@@ -6,13 +6,13 @@ const Emittery = require('../');
 
 const myEmitter = new Emittery();
 
-// Only accept one event data parameter
-myEmitter.emit('event', {a: true, b: true}, 'not', 'supported');
-
 // Does not provide a context either.
 myEmitter.on('event', function ({a, b}, ...args) {
 	console.log(a, b, args, this);
 });
+
+// Only accept one event data parameter
+myEmitter.emit('event', {a: true, b: true}, 'not', 'supported');
 
 // Prints:
 // 		true true [] undefined

--- a/index.js
+++ b/index.js
@@ -117,7 +117,9 @@ class Emittery {
 			getListeners(this, eventName).clear();
 		} else {
 			anyMap.get(this).clear();
-			eventsMap.get(this).clear();
+			for (const listeners of eventsMap.get(this).values()) {
+				listeners.clear();
+			}
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -56,29 +56,47 @@ class Emittery {
 
 	async emit(eventName, eventData) {
 		assertEventName(eventName);
-		const listeners = [...getListeners(this, eventName)];
-		const anyListeners = [...anyMap.get(this)];
+
+		const listeners = getListeners(this, eventName);
+		const anyListeners = anyMap.get(this);
+		const staticListeners = [...listeners];
+		const staticAnyListeners = [...anyListeners];
 
 		await resolvedPromise;
 		return Promise.all([
-			...listeners.map(async listener => listener(eventData)),
-			...anyListeners.map(async listener => listener(eventName, eventData))
+			...staticListeners.map(async listener => {
+				if (listeners.has(listener)) {
+					listener(eventData);
+				}
+			}),
+			...staticAnyListeners.map(async listener => {
+				if (anyListeners.has(listener)) {
+					listener(eventName, eventData);
+				}
+			})
 		]);
 	}
 
 	async emitSerial(eventName, eventData) {
 		assertEventName(eventName);
-		const listeners = [...getListeners(this, eventName)];
-		const anyListeners = [...anyMap.get(this)];
+
+		const listeners = getListeners(this, eventName);
+		const anyListeners = anyMap.get(this);
+		const staticListeners = [...listeners];
+		const staticAnyListeners = [...anyListeners];
 
 		await resolvedPromise;
 		/* eslint-disable no-await-in-loop */
-		for (const listener of listeners) {
-			await listener(eventData);
+		for (const listener of staticListeners) {
+			if (listeners.has(listener)) {
+				await listener(eventData);
+			}
 		}
 
-		for (const listener of anyListeners) {
-			await listener(eventName, eventData);
+		for (const listener of staticAnyListeners) {
+			if (anyListeners.has(listener)) {
+				await listener(eventName, eventData);
+			}
 		}
 		/* eslint-enable no-await-in-loop */
 	}

--- a/index.js
+++ b/index.js
@@ -66,12 +66,12 @@ class Emittery {
 		return Promise.all([
 			...staticListeners.map(async listener => {
 				if (listeners.has(listener)) {
-					listener(eventData);
+					return listener(eventData);
 				}
 			}),
 			...staticAnyListeners.map(async listener => {
 				if (anyListeners.has(listener)) {
-					listener(eventName, eventData);
+					return listener(eventName, eventData);
 				}
 			})
 		]);

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,13 @@ ee.emit('end'); // TS compilation error
 ```
 
 
+## Scheduling details
+
+Listeners are not invoked for events emitted *before* the listener was added. Removing a listener will prevent that listener from being invoked, even if events are in the process of being (asynchronously!) emitted. This also applies to `.clearListeners()`, which removes all listeners. Listeners will be called in the order they were added. So-called *any* listeners are called *after* event-specific listeners.
+
+Note that when using `.emitSerial()`, a slow listener will delay invocation of subsequent listeners. It's possible for newer events to overtake older ones.
+
+
 ## FAQ
 
 ### How is this different than the built-in `EventEmitter` in Node.js?

--- a/test/_run.js
+++ b/test/_run.js
@@ -190,6 +190,11 @@ module.exports = Emittery => {
 
 		await emitter.emit('🦄');
 		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
+
+		const p2 = emitter.emit('🦄');
+		emitter.clearListeners();
+		await p2;
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 	});
 
 	test.cb('emitSerial()', t => {
@@ -284,6 +289,11 @@ module.exports = Emittery => {
 		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9]);
 
 		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
+
+		const p2 = emitter.emitSerial('🦄');
+		emitter.clearListeners();
+		await p2;
 		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 	});
 

--- a/test/_run.js
+++ b/test/_run.js
@@ -171,16 +171,25 @@ module.exports = Emittery => {
 		off5();
 
 		let off8 = null;
-		emitter.onAny(() => {
+		emitter.on('🦄', () => {
 			calls.push(7);
 			off8();
 		});
-		off8 = emitter.onAny(() => calls.push(8));
+		off8 = emitter.on('🦄', () => calls.push(8));
 		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8]);
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6]);
+
+		let off10 = null;
+		emitter.onAny(() => {
+			calls.push(9);
+			off10();
+		});
+		off10 = emitter.onAny(() => calls.push(10));
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9]);
 
 		await emitter.emit('🦄');
-		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8, 2, 4, 6, 7]);
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 	});
 
 	test.cb('emitSerial()', t => {
@@ -257,16 +266,25 @@ module.exports = Emittery => {
 		off5();
 
 		let off8 = null;
-		emitter.onAny(() => {
+		emitter.on('🦄', () => {
 			calls.push(7);
 			off8();
 		});
-		off8 = emitter.onAny(() => calls.push(8));
+		off8 = emitter.on('🦄', () => calls.push(8));
 		await emitter.emitSerial('🦄');
-		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8]);
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6]);
+
+		let off10 = null;
+		emitter.onAny(() => {
+			calls.push(9);
+			off10();
+		});
+		off10 = emitter.onAny(() => calls.push(10));
+		await emitter.emitSerial('🦄');
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9]);
 
 		await emitter.emitSerial('🦄');
-		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 6, 7, 8, 2, 4, 6, 7]);
+		t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 	});
 
 	test('onAny()', async t => {


### PR DESCRIPTION
Follow-up to #26.