### PR TITLE
put babel config in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+	"plugins": [
+		"transform-async-to-generator"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -63,11 +63,6 @@
 		"typescript": "^2.9.0",
 		"xo": "*"
 	},
-	"babel": {
-		"plugins": [
-			"transform-async-to-generator"
-		]
-	},
 	"nyc": {
 		"reporter": [
 			"html",


### PR DESCRIPTION
Hello there !

First of all, thanks for the amazing work.

This PR removes the babel configuration from the `package.json` and puts it in a `.babelrc` file, which is then put in `.npmignore`.

I propose this, because Babel behaviour is very annoying, in that when babelifying stuff, it only takes into account the nearest babel config it finds, so I believe it's good practice not to publish your babel config.

I actually ran into hours of trouble after starting to use emittery in one of our packages, because it completely broke the build of a react-native app using said package because of this. Took us hours to figure out, then hours to work-around (the only work-around we could find was actually having an awful postinstall script that removes the `babel` key from emittery's `package.json` ...)

Thanks !