### PR TITLE
Support multiple events in on, off and once

### DIFF
--- a/Emittery.d.ts
+++ b/Emittery.d.ts
@@ -9,12 +9,12 @@ declare class Emittery {
 	 * Using the same listener multiple times for the same event will result
 	 * in only one method call per emitted event.
 	 */
-	on(eventName: string, listener: (eventData?: any) => any): Emittery.UnsubscribeFn;
+	on(eventName: string|string[], listener: (eventData?: any) => any): Emittery.UnsubscribeFn;
 
 	/**
 	 * Remove an event subscription.
 	 */
-	off(eventName: string, listener: (eventData?: any) => any): void;
+	off(eventName: string|string[], listener: (eventData?: any) => any): void;
 
 	/**
 	 * Subscribe to an event only once. It will be unsubscribed after the first
@@ -22,7 +22,7 @@ declare class Emittery {
 	 *
 	 * Returns a promise for the event data when `eventName` is emitted.
 	 */
-	once(eventName: string): Promise<any>;
+	once(eventName: string|string[]): Promise<any>;
 
 	/**
 	 * Trigger an event asynchronously, optionally with some data. Listeners

--- a/index.js
+++ b/index.js
@@ -31,23 +31,34 @@ class Emittery {
 		eventsMap.set(this, new Map());
 	}
 
-	on(eventName, listener) {
-		assertEventName(eventName);
+	on(eventNames, listener) {
 		assertListener(listener);
-		getListeners(this, eventName).add(listener);
-		return this.off.bind(this, eventName, listener);
-	}
 
-	off(eventName, listener) {
-		assertEventName(eventName);
-		assertListener(listener);
-		getListeners(this, eventName).delete(listener);
-	}
-
-	once(eventName) {
-		return new Promise(resolve => {
+		const events = Array.isArray(eventNames) ? eventNames : [eventNames];
+		events.forEach(eventName => {
 			assertEventName(eventName);
-			const off = this.on(eventName, data => {
+			getListeners(this, eventName).add(listener);
+		});
+
+		return this.off.bind(this, events, listener);
+	}
+
+	off(eventNames, listener) {
+		assertListener(listener);
+
+		const events = Array.isArray(eventNames) ? eventNames : [eventNames];
+		events.forEach(eventName => {
+			assertEventName(eventName);
+			getListeners(this, eventName).delete(listener);
+		});
+	}
+
+	once(eventNames) {
+		const events = Array.isArray(eventNames) ? eventNames : [eventNames];
+		events.forEach(eventName => assertEventName(eventName));
+
+		return new Promise(resolve => {
+			const off = this.on(events, data => {
 				off();
 				resolve(data);
 			});

--- a/readme.md
+++ b/readme.md
@@ -36,40 +36,70 @@ emitter.emit('🦄', '🌈');
 
 The above only works in Node.js 8 or newer. For older Node.js versions you can use `require('emittery/legacy')`.
 
-
 ## API
 
 ### emitter = new Emittery()
 
-#### on(eventName, listener)
+#### on([eventName], listener)
 
-Subscribe to an event.
+Subscribe to an event or multiple ones.
 
 Returns an unsubscribe method.
 
 Using the same listener multiple times for the same event will result in only one method call per emitted event.
 
+```js
+emitter.on('🦄').then(data => {
+	console.log(data);
+});
+
+emitter.on(['🦄', '🐶']).then(data => {
+	console.log(data);
+});
+
+emitter.emit('🦄', '🌈'); // log => '🌈'
+emitter.emit('🐶', '🍖'); // log => '🍖'
+```
+
 ##### listener(data)
 
-#### off(eventName, listener)
+#### off([eventName], listener)
 
-Remove an event subscription.
+Remove an event or multiple ones subscriptions.
+
+```js
+emitter.on(['🦄', '🐶']).then(data => {
+	console.log(data);
+});
+
+emitter.emit('🦄', '🌈');
+emitter.emit('🐶', '🍖');
+
+emitter.off('🦄');
+
+emitter.emit('🦄', '🌈'); // Nothing happens
+emitter.emit('🐶', '🍖'); // log => '🍖'
+```
 
 ##### listener(data)
 
-#### once(eventName)
+#### once([eventName])
 
-Subscribe to an event only once. It will be unsubscribed after the first event.
+Subscribe to an event or multiple ones only once. It will be unsubscribed after the first event.
 
 Returns a promise for the event data when `eventName` is emitted.
 
 ```js
 emitter.once('🦄').then(data => {
 	console.log(data);
-	//=> '🌈'
 });
 
-emitter.emit('🦄', '🌈');
+emitter.once(['🦄', '🐶']).then(data => {
+	console.log(data);
+});
+
+emitter.emit('🦄', '🌈'); // log => '🌈'
+emitter.emit('🐶', '🍖');	// log => '🍖'
 ```
 
 #### emit(eventName, [data])

--- a/test/_run.js
+++ b/test/_run.js
@@ -49,6 +49,17 @@ module.exports = Emittery => {
 		t.deepEqual(calls, [1]);
 	});
 
+	test('on() - multiple event names', async t => {
+		const emitter = new Emittery();
+		let count = 0;
+		const listener = () => ++count;
+
+		emitter.on(['🦄', '🐶'], listener);
+		await emitter.emit('🦄');
+		await emitter.emit('🐶');
+		t.is(count, 2);
+	});
+
 	test('off()', async t => {
 		const emitter = new Emittery();
 		const calls = [];
@@ -73,6 +84,24 @@ module.exports = Emittery => {
 		t.throws(() => emitter.off('🦄'), TypeError);
 	});
 
+	test('off() - multiple event names', async t => {
+		const emitter = new Emittery();
+		const calls = [];
+		const listener = () => calls.push(1);
+
+		emitter.on(['🦄', '🐶', '🦊'], listener);
+		await emitter.emit('🦄');
+		t.deepEqual(calls, [1]);
+
+		emitter.off(['🦄', '🐶'], listener);
+		await emitter.emit('🦄');
+		await emitter.emit('🐶');
+		t.deepEqual(calls, [1]);
+
+		await emitter.emit('🦊');
+		t.deepEqual(calls, [1, 1]);
+	});
+
 	test('once()', async t => {
 		const fixture = '🌈';
 		const emitter = new Emittery();
@@ -83,7 +112,17 @@ module.exports = Emittery => {
 
 	test('once() - eventName must be a string', async t => {
 		const emitter = new Emittery();
-		await t.throws(emitter.once(42), TypeError);
+		await t.throws(() => {
+			emitter.once(42);
+		}, TypeError);
+	});
+
+	test('once() - multiple event names', async t => {
+		const fixture = '🌈';
+		const emitter = new Emittery();
+		const promise = emitter.once(['🦄', '🐶']);
+		emitter.emit('🐶', fixture);
+		t.is(await promise, fixture);
 	});
 
 	test.cb('emit() - one event', t => {


### PR DESCRIPTION
Add support for multiple events in `on`, `off` and `once`. I started the implementation adding the `onMulti` method. However, I realized that the implementation with `string|string[]` is pretty clear and compatible with the current syntax of the methods. For that reason, I've implemented the PR in this way but feel free to ask me to define the new other methods.

**Changes**
* Support multiple events in `on`, `off` and `once`
* Add tests
* Improve docs

It closes #1