### PR TITLE
Allow symbol event names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+type EventName = string | symbol;
+
 declare class Emittery {
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.
@@ -23,7 +25,7 @@ declare class Emittery {
 
 	@returns An unsubscribe method.
 	*/
-	on(eventName: (string | symbol), listener: (eventData?: unknown) => void): Emittery.UnsubscribeFn;
+	on(eventName: EventName, listener: (eventData?: unknown) => void): Emittery.UnsubscribeFn;
 
 	/**
 	Get an async iterator which buffers data each time an event is emitted.
@@ -78,12 +80,12 @@ declare class Emittery {
 	}
 	```
 	*/
-	events(eventName:(string | symbol)): AsyncIterableIterator<unknown>
+	events(eventName:EventName): AsyncIterableIterator<unknown>
 
 	/**
 	Remove an event subscription.
 	*/
-	off(eventName: (string | symbol), listener: (eventData?: unknown) => void): void;
+	off(eventName: EventName, listener: (eventData?: unknown) => void): void;
 
 	/**
 	Subscribe to an event only once. It will be unsubscribed after the first
@@ -91,14 +93,14 @@ declare class Emittery {
 
 	@returns The event data when `eventName` is emitted.
 	*/
-	once(eventName: (string | symbol)): Promise<unknown>;
+	once(eventName: EventName): Promise<unknown>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
 	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
 	*/
-	emit(eventName: (string | symbol), eventData?: unknown): Promise<void>;
+	emit(eventName: EventName, eventData?: unknown): Promise<void>;
 
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
@@ -107,14 +109,14 @@ declare class Emittery {
 
 	@returns A promise that resolves when all the event listeners are done.
 	*/
-	emitSerial(eventName: (string | symbol), eventData?: unknown): Promise<void>;
+	emitSerial(eventName: EventName, eventData?: unknown): Promise<void>;
 
 	/**
 	Subscribe to be notified about any event.
 
 	@returns A method to unsubscribe.
 	*/
-	onAny(listener: (eventName: (string | symbol), eventData?: unknown) => unknown): Emittery.UnsubscribeFn;
+	onAny(listener: (eventName: EventName, eventData?: unknown) => unknown): Emittery.UnsubscribeFn;
 
 	/**
 	Get an async iterator which buffers a tuple of an event name and data each time an event is emitted.
@@ -155,19 +157,19 @@ declare class Emittery {
 	/**
 	Remove an `onAny` subscription.
 	*/
-	offAny(listener: (eventName: (string | symbol), eventData?: unknown) => void): void;
+	offAny(listener: (eventName: EventName, eventData?: unknown) => void): void;
 
 	/**
 	Clear all event listeners on the instance.
 
 	If `eventName` is given, only the listeners for that event are cleared.
 	*/
-	clearListeners(eventName?: string): void;
+	clearListeners(eventName?: EventName): void;
 
 	/**
 	The number of listeners for the `eventName` or all events if not specified.
 	*/
-	listenerCount(eventName?: string): number;
+	listenerCount(eventName?: EventName): number;
 
 	/**
 	Bind the given `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the `target` object.
@@ -191,13 +193,14 @@ declare namespace Emittery {
 	Removes an event subscription.
 	*/
 	type UnsubscribeFn = () => void;
+	type EventNameFromDataMap<EventDataMap> = Extract<keyof EventDataMap, EventName>;
 
 	/**
 	Maps event names to their emitted data type.
 	*/
 	interface Events {
 		// Blocked by https://github.com/microsoft/TypeScript/issues/1863, should be
-		// `[eventName: (string | symbol)]: unknown;`
+		// `[eventName: EventName]: unknown;`
 	}
 
 	/**
@@ -217,27 +220,27 @@ declare namespace Emittery {
 	emitter.emit('end'); // TS compilation error
 	```
 	*/
-	class Typed<EventDataMap extends Events, EmptyEvents extends (string | symbol) = never> extends Emittery {
-		on<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): Emittery.UnsubscribeFn;
+	class Typed<EventDataMap extends Events, EmptyEvents extends EventName = never> extends Emittery {
+		on<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): Emittery.UnsubscribeFn;
 		on<Name extends EmptyEvents>(eventName: Name, listener: () => void): Emittery.UnsubscribeFn;
 
-		events<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name): AsyncIterableIterator<EventDataMap[Name]>;
+		events<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name): AsyncIterableIterator<EventDataMap[Name]>;
 
-		once<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name): Promise<EventDataMap[Name]>;
+		once<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name): Promise<EventDataMap[Name]>;
 		once<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 
-		off<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): void;
+		off<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): void;
 		off<Name extends EmptyEvents>(eventName: Name, listener: () => void): void;
 
-		onAny(listener: (eventName: Extract<keyof EventDataMap, (string | symbol)> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): Emittery.UnsubscribeFn;
-		anyEvent(): AsyncIterableIterator<[Extract<keyof EventDataMap, string>, EventDataMap[Extract<keyof EventDataMap, string>]]>;
+		onAny(listener: (eventName: EventNameFromDataMap<EventDataMap> | EmptyEvents, eventData?: EventDataMap[EventNameFromDataMap<EventDataMap>]) => void): Emittery.UnsubscribeFn;
+		anyEvent(): AsyncIterableIterator<[EventNameFromDataMap<EventDataMap>, EventDataMap[EventNameFromDataMap<EventDataMap>]]>;
 
-		offAny(listener: (eventName: Extract<keyof EventDataMap, (string | symbol)> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): void;
+		offAny(listener: (eventName: EventNameFromDataMap<EventDataMap> | EmptyEvents, eventData?: EventDataMap[EventNameFromDataMap<EventDataMap>]) => void): void;
 
-		emit<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
+		emit<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
 		emit<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 
-		emitSerial<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
+		emitSerial<Name extends EventNameFromDataMap<EventDataMap>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
 		emitSerial<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+
 declare class Emittery {
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.
@@ -23,7 +24,7 @@ declare class Emittery {
 
 	@returns An unsubscribe method.
 	*/
-	on(eventName: string, listener: (eventData?: unknown) => void): Emittery.UnsubscribeFn;
+	on(eventName: (string | symbol), listener: (eventData?: unknown) => void): Emittery.UnsubscribeFn;
 
 	/**
 	Get an async iterator which buffers data each time an event is emitted.
@@ -78,12 +79,12 @@ declare class Emittery {
 	}
 	```
 	*/
-	events(eventName:string): AsyncIterableIterator<unknown>
+	events(eventName:(string | symbol)): AsyncIterableIterator<unknown>
 
 	/**
 	Remove an event subscription.
 	*/
-	off(eventName: string, listener: (eventData?: unknown) => void): void;
+	off(eventName: (string | symbol), listener: (eventData?: unknown) => void): void;
 
 	/**
 	Subscribe to an event only once. It will be unsubscribed after the first
@@ -91,14 +92,14 @@ declare class Emittery {
 
 	@returns The event data when `eventName` is emitted.
 	*/
-	once(eventName: string): Promise<unknown>;
+	once(eventName: (string | symbol)): Promise<unknown>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
 	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
 	*/
-	emit(eventName: string, eventData?: unknown): Promise<void>;
+	emit(eventName: (string | symbol), eventData?: unknown): Promise<void>;
 
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
@@ -107,14 +108,14 @@ declare class Emittery {
 
 	@returns A promise that resolves when all the event listeners are done.
 	*/
-	emitSerial(eventName: string, eventData?: unknown): Promise<void>;
+	emitSerial(eventName: (string | symbol), eventData?: unknown): Promise<void>;
 
 	/**
 	Subscribe to be notified about any event.
 
 	@returns A method to unsubscribe.
 	*/
-	onAny(listener: (eventName: string, eventData?: unknown) => unknown): Emittery.UnsubscribeFn;
+	onAny(listener: (eventName: (string | symbol), eventData?: unknown) => unknown): Emittery.UnsubscribeFn;
 
 	/**
 	Get an async iterator which buffers a tuple of an event name and data each time an event is emitted.
@@ -155,7 +156,7 @@ declare class Emittery {
 	/**
 	Remove an `onAny` subscription.
 	*/
-	offAny(listener: (eventName: string, eventData?: unknown) => void): void;
+	offAny(listener: (eventName: (string | symbol), eventData?: unknown) => void): void;
 
 	/**
 	Clear all event listeners on the instance.
@@ -196,7 +197,8 @@ declare namespace Emittery {
 	Maps event names to their emitted data type.
 	*/
 	interface Events {
-		[eventName: string]: any;
+		// Blocked by https://github.com/microsoft/TypeScript/issues/1863, should be
+		// `[eventName: (string | symbol)]: unknown;`
 	}
 
 	/**
@@ -216,27 +218,27 @@ declare namespace Emittery {
 	emitter.emit('end'); // TS compilation error
 	```
 	*/
-	class Typed<EventDataMap extends Events, EmptyEvents extends string = never> extends Emittery {
-		on<Name extends Extract<keyof EventDataMap, string>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): Emittery.UnsubscribeFn;
+	class Typed<EventDataMap extends Events, EmptyEvents extends (string | symbol) = never> extends Emittery {
+		on<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): Emittery.UnsubscribeFn;
 		on<Name extends EmptyEvents>(eventName: Name, listener: () => void): Emittery.UnsubscribeFn;
 
-		events<Name extends Extract<keyof EventDataMap, string>>(eventName: Name): AsyncIterableIterator<EventDataMap[Name]>;
+		events<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name): AsyncIterableIterator<EventDataMap[Name]>;
 
-		once<Name extends Extract<keyof EventDataMap, string>>(eventName: Name): Promise<EventDataMap[Name]>;
+		once<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name): Promise<EventDataMap[Name]>;
 		once<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 
-		off<Name extends Extract<keyof EventDataMap, string>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): void;
+		off<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, listener: (eventData: EventDataMap[Name]) => void): void;
 		off<Name extends EmptyEvents>(eventName: Name, listener: () => void): void;
 
-		onAny(listener: (eventName: Extract<keyof EventDataMap, string> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): Emittery.UnsubscribeFn;
+		onAny(listener: (eventName: Extract<keyof EventDataMap, (string | symbol)> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): Emittery.UnsubscribeFn;
 		anyEvent(): AsyncIterableIterator<[Extract<keyof EventDataMap, string>, EventDataMap[Extract<keyof EventDataMap, string>]]>;
 
-		offAny(listener: (eventName: Extract<keyof EventDataMap, string> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): void;
+		offAny(listener: (eventName: Extract<keyof EventDataMap, (string | symbol)> | EmptyEvents, eventData?: EventDataMap[Extract<keyof EventDataMap, string>]) => void): void;
 
-		emit<Name extends Extract<keyof EventDataMap, string>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
+		emit<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
 		emit<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 
-		emitSerial<Name extends Extract<keyof EventDataMap, string>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
+		emitSerial<Name extends Extract<keyof EventDataMap, (string | symbol)>>(eventName: Name, eventData: EventDataMap[Name]): Promise<void>;
 		emitSerial<Name extends EmptyEvents>(eventName: Name): Promise<void>;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-
 declare class Emittery {
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const anyProducer = Symbol('anyProducer');
 const resolvedPromise = Promise.resolve();
 
 function assertEventName(eventName) {
-	if (typeof eventName !== 'string') {
-		throw new TypeError('eventName must be a string');
+	if (typeof eventName !== 'string' && typeof eventName !== 'symbol') {
+		throw new TypeError('eventName must be a string or a symbol');
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -23,16 +23,28 @@ const Emittery = require('emittery');
 
 const emitter = new Emittery();
 
+const myEvent = Symbol('my symbol event');
+
 emitter.on('🦄', data => {
-	console.log(data);
-	// '🌈'
+	console.log(data); // '🌈'
+});
+
+emitter.on(myEvent, data => {
+	console.log(data); // '🦋'
 });
 
 emitter.emit('🦄', '🌈');
+emitter.emit(myEvent, '🦋')
+
 ```
 
 
 ## API
+
+### eventName
+
+Emittery accepts strings and symbols as event names.
+Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
 ### emitter = new Emittery()
 

--- a/readme.md
+++ b/readme.md
@@ -23,18 +23,18 @@ const Emittery = require('emittery');
 
 const emitter = new Emittery();
 
-const myEvent = Symbol('my symbol event');
-
 emitter.on('🦄', data => {
-	console.log(data); // '🌈'
+	console.log(data);
 });
 
-emitter.on(myEvent, data => {
-	console.log(data); // '🦋'
+const myUnicorn = Symbol('🦄');
+
+emitter.on(myUnicorn, data => {
+	console.log(`Unicorns love ${data}`);
 });
 
-emitter.emit('🦄', '🌈');
-emitter.emit(myEvent, '🦋')
+emitter.emit('🦄', '🌈'); // Will trigger printing '🌈'
+emitter.emit(myUnicorn, '🦋');  // Will trigger printing 'Unicorns love 🦋'
 
 ```
 

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,23 @@ test('on()', async t => {
 	t.deepEqual(calls, [1, 2]);
 });
 
-test('on() - eventName must be a string', t => {
+test('on() - symbol eventName', async t => {
 	const emitter = new Emittery();
+	const eventName = Symbol('eventName');
+	const calls = [];
+	const listener1 = () => calls.push(1);
+	const listener2 = () => calls.push(2);
+	emitter.on(eventName, listener1);
+	emitter.on(eventName, listener2);
+	await emitter.emit(eventName);
+	t.deepEqual(calls, [1, 2]);
+});
+
+test('on() - eventName must be a string or a symbol', t => {
+	const emitter = new Emittery();
+
+	emitter.on('string', () => {});
+	emitter.on(Symbol('symbol'), () => {});
 
 	t.throws(() => {
 		emitter.on(42, () => {});
@@ -161,8 +176,12 @@ test('once()', async t => {
 	t.is(await promise, fixture);
 });
 
-test('once() - eventName must be a string', async t => {
+test('once() - eventName must be a string or a symbol', async t => {
 	const emitter = new Emittery();
+
+	emitter.once('string');
+	emitter.once(Symbol('symbol'));
+
 	await t.throwsAsync(emitter.once(42), TypeError);
 });
 
@@ -204,6 +223,10 @@ test.cb('emit() - multiple events', t => {
 
 test('emit() - eventName must be a string', async t => {
 	const emitter = new Emittery();
+
+	emitter.emit('string');
+	emitter.emit(Symbol('symbol'));
+
 	await t.throwsAsync(emitter.emit(42), TypeError);
 });
 
@@ -304,6 +327,10 @@ test.cb('emitSerial()', t => {
 
 test('emitSerial() - eventName must be a string', async t => {
 	const emitter = new Emittery();
+
+	emitter.emitSerial('string');
+	emitter.emitSerial(Symbol('symbol'));
+
 	await t.throwsAsync(emitter.emitSerial(42), TypeError);
 });
 
@@ -562,8 +589,11 @@ test('listenerCount() - works with empty eventName strings', t => {
 	t.is(emitter.listenerCount(''), 1);
 });
 
-test('listenerCount() - eventName must be undefined if not a string', t => {
+test('listenerCount() - eventName must be undefined if not a string nor a symbol', t => {
 	const emitter = new Emittery();
+
+	emitter.listenerCount('string');
+	emitter.listenerCount(Symbol('symbol'));
 
 	t.throws(() => {
 		emitter.listenerCount(42);

--- a/test/index.js
+++ b/test/index.js
@@ -152,8 +152,11 @@ test('off()', async t => {
 	t.deepEqual(calls, [1]);
 });
 
-test('off() - eventName must be a string', t => {
+test('off() - eventName must be a string or a symbol', t => {
 	const emitter = new Emittery();
+
+	emitter.on('string', () => {});
+	emitter.on(Symbol('symbol'), () => {});
 
 	t.throws(() => {
 		emitter.off(42);
@@ -221,7 +224,7 @@ test.cb('emit() - multiple events', t => {
 	emitter.emit('🦄');
 });
 
-test('emit() - eventName must be a string', async t => {
+test('emit() - eventName must be a string or a symbol', async t => {
 	const emitter = new Emittery();
 
 	emitter.emit('string');
@@ -325,7 +328,7 @@ test.cb('emitSerial()', t => {
 	emitter.emitSerial('🦄', 'e');
 });
 
-test('emitSerial() - eventName must be a string', async t => {
+test('emitSerial() - eventName must be a string or a symbol', async t => {
 	const emitter = new Emittery();
 
 	emitter.emitSerial('string');
@@ -594,6 +597,7 @@ test('listenerCount() - eventName must be undefined if not a string nor a symbol
 
 	emitter.listenerCount('string');
 	emitter.listenerCount(Symbol('symbol'));
+	emitter.listenerCount();
 
 	t.throws(() => {
 		emitter.listenerCount(42);


### PR DESCRIPTION
Fixes #16 

In typescript, complete typing is blocked by https://github.com/microsoft/TypeScript/issues/1863 at the moment, so we relax typing a bit. This relaxation affects defining `EventDataMap` with number indexes, so `Emittery.Typed<{123: string}, 'someevent'>` causes no compile time error. However, *using* any such event will still cause compile time error.

:unicorn: 
<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#16: Support Symbol as `eventName`](https://issuehunt.io/repos/112248999/issues/16)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->