### PR TITLE
Add debug functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,24 @@ declare class Emittery<
 	DatalessEvents = DatalessEventNames<EventData>
 > {
 	/**
+	Controls debug mode for all instances
+
+	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false
+	@example
+	```
+	const Emittery = require('emittery');
+	Emittery.isDebug = true;
+
+	const emitter = new Emittery({debugName: 'myEmitter'});
+	emitter.on('test', data => { // do something });
+
+	//=> [emittery:subscribe][myEmitter] Event Name: test
+	//	data: undefined
+	```
+	*/
+	static isDebug: boolean;
+
+	/**
 	Fires when an event listener was added.
 
 	An object with `listener` and `eventName` (if `on` or `off` was used) is provided as event data.
@@ -131,6 +149,49 @@ declare class Emittery<
 	static readonly listenerRemoved: typeof listenerRemoved;
 
 	/**
+	Handles debug data, by default it prints it to the console.
+
+	@default Prints the type, debugName, eventName and eventData to the console
+	@example
+	```
+	const Emittery = require('emittery');
+	Emittery.isDebug = true;
+	Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
+
+	const emitter = new Emittery();
+	emitter.on('test', data => { // do something });
+
+	//=> [subscribe]: test
+	```
+	*/
+	debugLogger: DebugLogger;
+
+	/**
+	Enables debug output for this instance of Emittery
+
+	@default false
+	@example
+	```
+	const Emittery = require('emittery');
+
+	const emitter = new Emittery({debugName: 'myEmitter'});
+	emitter.isDebug = true;
+	emitter.on('test', data => { // do something });
+
+	//=> [emittery:subscribe][myEmitter] Event Name: test
+	//	data: undefined
+	```
+	*/
+	isDebug: boolean;
+
+	/**
+	Create a new Emittery instance with the specified opitons
+
+	@returns An instance of Emittery that you can use to listen for and emit events
+	*/
+	constructor(options?: Options);
+
+	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.
 
 	@example
@@ -149,49 +210,6 @@ declare class Emittery<
 		emitteryPropertyName: string | symbol,
 		methodNames?: readonly string[]
 	): <T extends { new (): any }>(klass: T) => T; // eslint-disable-line @typescript-eslint/prefer-function-type
-
-	/**
-	Handles debug data, by default it prints it to the console.
-
-	@default Prints the type, debugName, eventName and eventData to the console
-	@example
-	```
-	const Emittery = require('emittery');
-	Emittery.isDebug = true;
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
-
-	const emitter = new Emittery();
-	emitter.on('test', data => { // do something });
-
-	//=> [subscribe]: test
-	```
-	*/
-	static debugLogger: DebugLogger;
-
-	/**
-	Controls debug mode for all instances
-
-	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false
-	@example
-	```
-	const Emittery = require('emittery');
-	Emittery.isDebug = true;
-
-	const emitter = new Emittery({debugName: 'myEmitter'});
-	emitter.on('test', data => { // do something });
-
-	//=> [emittery:subscribe][myEmitter] Event Name: test
-	//	data: undefined
-	```
-	*/
-	static isDebug: boolean;
-
-	/**
-	Create a new Emittery instance with the specified opitons
-
-	@returns An instance of Emittery that you can use to listen for and emit events
-	*/
-	constructor(options?: Options);
 
 	/**
 	Subscribe to one or more events.
@@ -474,24 +492,6 @@ declare class Emittery<
 	```
 	*/
 	bindMethods(target: Record<string, unknown>, methodNames?: readonly string[]): void;
-
-	/**
-	Enables debug output for this instance of Emittery
-
-	@default false
-	@example
-	```
-	const Emittery = require('emittery');
-
-	const emitter = new Emittery({debugName: 'myEmitter'});
-	emitter.isDebug = true;
-	emitter.on('test', data => { // do something });
-
-	//=> [emittery:subscribe][myEmitter] Event Name: test
-	//	data: undefined
-	```
-	*/
-	isDebug: boolean;
 }
 
 declare namespace Emittery {

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,6 +105,8 @@ interface DebugOptions<EventData> {
 
 	emitter.on('test', data => { // do something });
 
+	emitter.emit('test');
+
 	//=> [subscribe]: test
 	```
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,8 +30,6 @@ interface DebugOptions<EventData> {
 	/**
 	Define a name for the instance of Emittery to use when outputting debug data.
 
-	@default null
-
 	@example
 	```
 	const Emittery = require('emittery');
@@ -46,7 +44,7 @@ interface DebugOptions<EventData> {
 	//	data: undefined
 	```
 	*/
-	readonly name: string | null;
+	readonly name: string;
 
 	/**
 	Toggle debug logging just for this instance.

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,8 @@ interface DebugOptions<EventData> {
 	/**
 	Define a name for the instance of Emittery to use when outputting debug data.
 
+	@default undefined
+
 	@example
 	```
 	const Emittery = require('emittery');
@@ -48,6 +50,8 @@ interface DebugOptions<EventData> {
 
 	/**
 	Toggle debug logging just for this instance.
+
+	@default false
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,14 +13,9 @@ type EventNames = EventName | readonly EventName[];
 /**
 Emittery can log debug output to console, this function takes care of outputting log data.
 
-To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the 'isDebug' option to true on the Emittery class, or an instance of it for debugging a single instance.
+To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the 'isDebug' option to true on the Emittery class, or on an instance of it for debugging a single instance.
 */
 type DebugLogger = (type: string, debugName: string, eventName?: EventName, eventData?: unknown) => void;
-
-/**
-Decides if Emittery should be in debug mode.
-*/
-type DebugPredicate = () => boolean;
 
 /**
 Configure the new instance of Emittery
@@ -31,7 +26,7 @@ interface Options {
 	@example
 	```
 	const Emittery = require('emittery');
-	Emittery.isDebug = () => true;
+	Emittery.isDebug = true;
 	const emitter = new Emittery({debugName: "myEmitter"});
 	emitter.on('test', data => { // do something });
 	//=> [emittery:subscribe][myEmitter] Event Name: test
@@ -114,13 +109,13 @@ declare class Emittery {
 	static readonly listenerRemoved: unique symbol;
 
 	/**
-	Handles debug data, by default it print it to the console.
+	Handles debug data, by default it prints it to the console.
 
 	@default Prints the type, debugName, eventName and eventData to the console
 	@example
 	```
 	const Emittery = require('emittery');
-	Emittery.isDebug = () => true;
+	Emittery.isDebug = true;
 	Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
 
 	const emitter = new Emittery();
@@ -138,7 +133,7 @@ declare class Emittery {
 	@example
 	```
 	const Emittery = require('emittery');
-	Emittery.isDebug = () => true;
+	Emittery.isDebug = true;
 
 	const emitter = new Emittery({debugName: 'myEmitter'});
 	emitter.on('test', data => { // do something });
@@ -147,7 +142,7 @@ declare class Emittery {
 	//	data: undefined
 	```
 	*/
-	static isDebug: DebugPredicate;
+	static isDebug: boolean;
 
 	/**
 	Create a new Emittery instance with the specified opitons

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,27 +17,52 @@ type OmnipresentEventData = {[listenerAdded]: Emittery.ListenerChangedData; [lis
 /**
 Emittery can log debug output to console, this function takes care of outputting log data.
 
-To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the 'isDebug' option to true on the Emittery class, or on an instance of it for debugging a single instance.
+To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the 'isDebug' option to true on the Emittery class, or 'myEmitter.debug.enabled' on an instance of it for debugging a single instance.
 */
-type DebugLogger = (type: string, debugName: string, eventName?: EventName, eventData?: unknown) => void;
+type DebugLogger = (type: string, debugName: string, eventName?: EventName, eventData?: Record<string, any>) => void;
 
 /**
-Configure the new instance of Emittery
+Configure debug options of the instance
 */
-interface Options {
+interface DebugOptions {
 	/**
 	Define a name for the instance of Emittery to use when outputting debug data.
+
 	@example
 	```
 	const Emittery = require('emittery');
 	Emittery.isDebug = true;
-	const emitter = new Emittery({debugName: "myEmitter"});
+	const emitter = new Emittery({debug: {name: 'myEmitter'}});
 	emitter.on('test', data => { // do something });
 	//=> [emittery:subscribe][myEmitter] Event Name: test
 	//	data: undefined
 	```
 	*/
-	readonly debugName?: string;
+	name: string;
+
+	/**
+	Enable debug logging just for this instance
+
+	@default false - instance debug logging is not enabled by default
+	@example
+	```
+	const Emittery = require('emittery');
+	const emitter1 = new Emittery({debug: {name: 'emitter1', enabled: true}});
+	const emitter2 = new Emittery({debug: {name: 'emitter2'}});
+	emitter1.on('test', data => { // do something });
+	emitter2.on('test', data => { // do something });
+	//=> [emittery:subscribe][emitter1] Event Name: test
+	//	data: undefined
+	```
+	*/
+	enabled?: boolean;
+}
+
+/**
+Configure the new instance of Emittery
+*/
+interface Options {
+	debug?: DebugOptions;
 }
 
 /**
@@ -77,7 +102,7 @@ declare class Emittery<
 	DatalessEvents = DatalessEventNames<EventData>
 > {
 	/**
-	Controls debug mode for all instances
+	Enables/Disables debug mode for all instances
 
 	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false
 	@example
@@ -151,7 +176,7 @@ declare class Emittery<
 	/**
 	Handles debug data, by default it prints it to the console.
 
-	@default Prints the type, debugName, eventName and eventData to the console
+	@default Prints the time(hh:mm:ss.mmm), type, debugName, eventName and eventData to the console
 	@example
 	```
 	const Emittery = require('emittery');
@@ -165,24 +190,6 @@ declare class Emittery<
 	```
 	*/
 	debugLogger: DebugLogger;
-
-	/**
-	Enables debug output for this instance of Emittery
-
-	@default false
-	@example
-	```
-	const Emittery = require('emittery');
-
-	const emitter = new Emittery({debugName: 'myEmitter'});
-	emitter.isDebug = true;
-	emitter.on('test', data => { // do something });
-
-	//=> [emittery:subscribe][myEmitter] Event Name: test
-	//	data: undefined
-	```
-	*/
-	isDebug: boolean;
 
 	/**
 	Create a new Emittery instance with the specified opitons

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,9 @@ Decides if Emittery should be in debug mode.
 */
 type DebugPredicate = () => boolean;
 
+/**
+Configure the new instance of Emittery
+*/
 interface Options {
 	/**
 	Define a name for the instance of Emittery to use when outputting debug data.
@@ -26,8 +29,8 @@ interface Options {
 	Emittery.isDebug = () => true;
 	const emitter = new Emittery({debugName: "myEmitter"});
 	emitter.on('test', data => { // do something });
-	//=> [emitter:subscribe][myEmitter] Event Name: test
-		data: undefined
+	//=> [emittery:subscribe][myEmitter] Event Name: test
+	//	data: undefined
 	```
 	*/
 	readonly debugName?: string;
@@ -114,8 +117,10 @@ declare class Emittery {
 	const Emittery = require('emittery');
 	Emittery.isDebug = () => true;
 	Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
+
 	const emitter = new Emittery();
 	emitter.on('test', data => { // do something });
+
 	//=> [subscribe]: test
 	```
 	*/
@@ -129,10 +134,12 @@ declare class Emittery {
 	```
 	const Emittery = require('emittery');
 	Emittery.isDebug = () => true;
+
 	const emitter = new Emittery({debugName: 'myEmitter'});
 	emitter.on('test', data => { // do something });
+
 	//=> [emittery:subscribe][myEmitter] Event Name: test
-		data: undefined
+	//	data: undefined
 	```
 	*/
 	static isDebug: DebugPredicate;
@@ -314,6 +321,24 @@ declare class Emittery {
 	```
 	*/
 	bindMethods(target: object, methodNames?: readonly string[]): void;
+
+	/**
+	Enables debug output for this instance of Emittery
+
+	@default false
+	@example
+	```
+	const Emittery = require('emittery');
+
+	const emitter = new Emittery({debugName: 'myEmitter'});
+	emitter.isDebug = true;
+	emitter.on('test', data => { // do something });
+
+	//=> [emittery:subscribe][myEmitter] Event Name: test
+	//	data: undefined
+	```
+	*/
+	isDebug: boolean;
 }
 
 declare namespace Emittery {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,40 +19,51 @@ Emittery can collect and log debug information.
 
 To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the static `isDebug` variable to true on the Emittery class, or `myEmitter.debug.enabled` on an instance of it for debugging a single instance.
 
-See API for more information on how debugging works
+See API for more information on how debugging works.
 */
-type DebugLogger = (type: string, debugName: string, eventName?: EventName, eventData?: Record<string, any>) => void;
+type DebugLogger<EventData, Name extends keyof EventData> = (type: string, debugName: string, eventName?: Name, eventData?: EventData[Name]) => void;
 
 /**
-Configure debug options of an instance
+Configure debug options of an instance.
 */
-interface DebugOptions {
+interface DebugOptions<EventData> {
 	/**
 	Define a name for the instance of Emittery to use when outputting debug data.
 
-	@default Empty string
+	@default null
+
 	@example
 	```
 	const Emittery = require('emittery');
 	Emittery.isDebug = true;
+
 	const emitter = new Emittery({debug: {name: 'myEmitter'}});
 	emitter.on('test', data => { // do something });
+
+	emitter.emit('test');
+
 	//=> [16:43:20.417][emittery:subscribe][myEmitter] Event Name: test
 	//	data: undefined
 	```
 	*/
-	name: string;
+	readonly name: string;
 
 	/**
-	Enable/Disable debug logging just for this instance
+	Toggle debug logging just for this instance.
 
 	@example
 	```
 	const Emittery = require('emittery');
+
 	const emitter1 = new Emittery({debug: {name: 'emitter1', enabled: true}});
 	const emitter2 = new Emittery({debug: {name: 'emitter2'}});
+
 	emitter1.on('test', data => { // do something });
 	emitter2.on('test', data => { // do something });
+
+	emitter1.emit('test');
+	emitter2.emit('test');
+
 	//=> [16:43:20.417][emittery:subscribe][emitter1] Event Name: test
 	//	data: undefined
 	```
@@ -60,7 +71,7 @@ interface DebugOptions {
 	enabled?: boolean;
 
 	/**
-	Function that handles debug data
+	Function that handles debug data.
 
 	@default
 	```
@@ -78,6 +89,7 @@ interface DebugOptions {
 		console.log(`[${logTime}][emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
 	}
 	```
+
 	@example
 	```
 	const Emittery = require('emittery');
@@ -90,19 +102,20 @@ interface DebugOptions {
 			logger: myLogger
 		}
 	});
+
 	emitter.on('test', data => { // do something });
 
 	//=> [subscribe]: test
 	```
 	*/
-	logger?: DebugLogger;
+	logger?: DebugLogger<EventData, keyof EventData>;
 }
 
 /**
-Configure a new instance of Emittery
+Configuration options for Emittery.
 */
-interface Options {
-	debug?: DebugOptions;
+interface Options<EventData> {
+	debug?: DebugOptions<EventData>;
 }
 
 /**
@@ -142,9 +155,10 @@ declare class Emittery<
 	DatalessEvents = DatalessEventNames<EventData>
 > {
 	/**
-	Enables/Disables debug mode for all instances
+	Toggle debug mode for all instances.
 
-	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false
+	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
+
 	@example
 	```
 	const Emittery = require('emittery');
@@ -152,11 +166,16 @@ declare class Emittery<
 
 	const emitter1 = new Emittery({debug: {name: 'myEmitter1'}});
 	const emitter2 = new Emittery({debug: {name: 'myEmitter2'}});
+
 	emitter1.on('test', data => { // do something });
 	emitter2.on('otherTest', data => { // do something });
 
+	emitter1.emit('test');
+	emitter2.emit('otherTest');
+
 	//=> [16:43:20.417][emittery:subscribe][myEmitter1] Event Name: test
 	//	data: undefined
+
 	//=> [16:43:20.417][emittery:subscribe][myEmitter2] Event Name: otherTest
 	//	data: undefined
 	```
@@ -218,37 +237,16 @@ declare class Emittery<
 	static readonly listenerRemoved: typeof listenerRemoved;
 
 	/**
-	Debugging options for the current instance
-
-	@default
-	```
-	{
-		name: '',
-		enabled: false,
-		logger: (type, debugName, eventName, eventData) => {
-			if (typeof eventData === 'object') {
-				eventData = JSON.stringify(eventData);
-			}
-
-			if (typeof eventName === 'symbol') {
-				eventName = eventName.toString();
-			}
-
-			const currentTime = new Date();
-			const logTime = `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}.${currentTime.getMilliseconds()}`;
-			console.log(`[${logTime}][emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
-		}
-	}
-	```
+	Debugging options for the current instance.
 	*/
-	debug: DebugOptions;
+	debug: DebugOptions<EventData>;
 
 	/**
-	Create a new Emittery instance with the specified options
+	Create a new Emittery instance with the specified options.
 
-	@returns An instance of Emittery that you can use to listen for and emit events
+	@returns An instance of Emittery that you can use to listen for and emit events.
 	*/
-	constructor(options?: Options);
+	constructor(options?: Options<EventData>);
 
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,34 @@ Symbol event names can be used to avoid name collisions when your classes are ex
 */
 type EventName = string | symbol;
 
+/**
+Emittery can log debug output to console, this function takes care of outputting log data.
+
+To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the 'isDebug' option to true on the Emittery class, or an instance of it for debugging a single instance.
+*/
+type DebugLogger = (type: string, debugName: string, eventName?: EventName, eventData?: unknown) => void;
+
+/**
+Decides if Emittery should be in debug mode.
+*/
+type DebugPredicate = () => boolean;
+
+interface Options {
+	/**
+	Define a name for the instance of Emittery to use when outputting debug data.
+	@example
+	```
+	const Emittery = require('emittery');
+	Emittery.isDebug = () => true;
+	const emitter = new Emittery({debugName: "myEmitter"});
+	emitter.on('test', data => { // do something });
+	//=> [emitter:subscribe][myEmitter] Event Name: test
+		data: undefined
+	```
+	*/
+	readonly debugName?: string;
+}
+
 declare class Emittery {
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.
@@ -76,6 +104,45 @@ declare class Emittery {
 	```
 	*/
 	static readonly listenerRemoved: unique symbol;
+
+	/**
+	Handles debug data, by default it print it to the console.
+
+	@default Prints the type, debugName, eventName and eventData to the console
+	@example
+	```
+	const Emittery = require('emittery');
+	Emittery.isDebug = () => true;
+	Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
+	const emitter = new Emittery();
+	emitter.on('test', data => { // do something });
+	//=> [subscribe]: test
+	```
+	*/
+	static debugLogger: DebugLogger;
+
+	/**
+	Controls debug mode for all instances
+
+	@default Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false
+	@example
+	```
+	const Emittery = require('emittery');
+	Emittery.isDebug = () => true;
+	const emitter = new Emittery({debugName: 'myEmitter'});
+	emitter.on('test', data => { // do something });
+	//=> [emittery:subscribe][myEmitter] Event Name: test
+		data: undefined
+	```
+	*/
+	static isDebug: DebugPredicate;
+
+	/**
+	Create a new Emittery instance with the specified opitons
+
+	@returns An instance of Emittery that you can use to listen for and emit events
+	*/
+	constructor(options?: Options);
 
 	/**
 	Subscribe to an event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ type OmnipresentEventData = {[listenerAdded]: Emittery.ListenerChangedData; [lis
 /**
 Emittery can collect and log debug information.
 
-To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the static `isDebug` variable to true on the Emittery class, or `myEmitter.debug.enabled` on an instance of it for debugging a single instance.
+To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the static `isDebugEnabled` variable to true on the Emittery class, or `myEmitter.debug.enabled` on an instance of it for debugging a single instance.
 
 See API for more information on how debugging works.
 */
@@ -35,7 +35,7 @@ interface DebugOptions<EventData> {
 	@example
 	```
 	const Emittery = require('emittery');
-	Emittery.isDebug = true;
+	Emittery.isDebugEnabled = true;
 
 	const emitter = new Emittery({debug: {name: 'myEmitter'}});
 	emitter.on('test', data => { // do something });
@@ -46,7 +46,7 @@ interface DebugOptions<EventData> {
 	//	data: undefined
 	```
 	*/
-	readonly name: string;
+	readonly name: string | null;
 
 	/**
 	Toggle debug logging just for this instance.
@@ -76,9 +76,7 @@ interface DebugOptions<EventData> {
 	@default
 	```
 	(type, debugName, eventName, eventData) => {
-		if (typeof eventData === 'object') {
-			eventData = JSON.stringify(eventData);
-		}
+		eventData = JSON.stringify(eventData);
 
 		if (typeof eventName === 'symbol') {
 			eventName = eventName.toString();
@@ -162,7 +160,7 @@ declare class Emittery<
 	@example
 	```
 	const Emittery = require('emittery');
-	Emittery.isDebug = true;
+	Emittery.isDebugEnabled = true;
 
 	const emitter1 = new Emittery({debug: {name: 'myEmitter1'}});
 	const emitter2 = new Emittery({debug: {name: 'myEmitter2'}});
@@ -180,7 +178,7 @@ declare class Emittery<
 	//	data: undefined
 	```
 	*/
-	static isDebug: boolean;
+	static isDebugEnabled: boolean;
 
 	/**
 	Fires when an event listener was added.

--- a/index.js
+++ b/index.js
@@ -199,25 +199,34 @@ class Emittery {
 		globalDebugFlag = newValue;
 	}
 
-	debugLogger(type, debugName, eventName, eventData) {
-		if (typeof eventData === 'object') {
-			eventData = JSON.stringify(eventData);
-		}
-
-		if (typeof eventName === 'symbol') {
-			eventName = eventName.toString();
-		}
-
-		const currentTime = new Date();
-		const logTime = `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}.${currentTime.getMilliseconds()}`;
-		console.log(`[${logTime}][emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
-	}
-
 	constructor(options = {}) {
 		anyMap.set(this, new Set());
 		eventsMap.set(this, new Map());
 		producersMap.set(this, new Map());
-		this.debug = options.debug || {name: '', enabled: false};
+		this.debug = options.debug || {};
+		if (!this.debug.name) {
+			this.debug.name = '';
+		}
+
+		if (!this.debug.enabled) {
+			this.debug.enabled = false;
+		}
+
+		if (!this.debug.logger) {
+			this.debug.logger = (type, debugName, eventName, eventData) => {
+				if (typeof eventData === 'object') {
+					eventData = JSON.stringify(eventData);
+				}
+
+				if (typeof eventName === 'symbol') {
+					eventName = eventName.toString();
+				}
+
+				const currentTime = new Date();
+				const logTime = `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}.${currentTime.getMilliseconds()}`;
+				console.log(`[${logTime}][emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
+			};
+		}
 	}
 
 	on(eventNames, listener) {
@@ -229,7 +238,7 @@ class Emittery {
 			getListeners(this, eventName).add(listener);
 
 			if (Emittery.isDebug || this.debug.enabled) {
-				this.debugLogger('subscribe', this.debug.name, eventName, undefined);
+				this.debug.logger('subscribe', this.debug.name, eventName, undefined);
 			}
 
 			if (!isListenerSymbol(eventName)) {
@@ -249,7 +258,7 @@ class Emittery {
 			getListeners(this, eventName).delete(listener);
 
 			if (Emittery.isDebug || this.debug.enabled) {
-				this.debugLogger('unsubscribe', this.debug.name, eventName, undefined);
+				this.debug.logger('unsubscribe', this.debug.name, eventName, undefined);
 			}
 
 			if (!isListenerSymbol(eventName)) {
@@ -280,7 +289,7 @@ class Emittery {
 		assertEventName(eventName);
 
 		if (Emittery.isDebug || this.debug.enabled) {
-			this.debugLogger('emit', this.debug.name, eventName, eventData);
+			this.debug.logger('emit', this.debug.name, eventName, eventData);
 		}
 
 		enqueueProducers(this, eventName, eventData);
@@ -309,7 +318,7 @@ class Emittery {
 		assertEventName(eventName);
 
 		if (Emittery.isDebug || this.debug.enabled) {
-			this.debugLogger('emitSerial', this.debug.name, eventName, eventData);
+			this.debug.logger('emitSerial', this.debug.name, eventName, eventData);
 		}
 
 		const listeners = getListeners(this, eventName);
@@ -336,7 +345,7 @@ class Emittery {
 	onAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug || this.debug.enabled) {
-			this.debugLogger('subscribeAny', this.debug.name, undefined, undefined);
+			this.debug.logger('subscribeAny', this.debug.name, undefined, undefined);
 		}
 
 		anyMap.get(this).add(listener);
@@ -351,7 +360,7 @@ class Emittery {
 	offAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug || this.debug.enabled) {
-			this.debugLogger('unsubscribeAny', this.debug.name, undefined, undefined);
+			this.debug.logger('unsubscribeAny', this.debug.name, undefined, undefined);
 		}
 
 		this.emit(listenerRemoved, {listener});
@@ -363,7 +372,7 @@ class Emittery {
 
 		for (const eventName of eventNames) {
 			if (Emittery.isDebug || this.debug.enabled) {
-				this.debugLogger('clear', this.debug.name, eventName, undefined);
+				this.debug.logger('clear', this.debug.name, eventName, undefined);
 			}
 
 			if (typeof eventName === 'string' || typeof eventName === 'symbol') {

--- a/index.js
+++ b/index.js
@@ -200,10 +200,6 @@ class Emittery {
 	}
 
 	static debugLogger(type, debugName, eventName, eventData) {
-		if (typeof eventName !== 'string') {
-			eventName = eventName.toString();
-		}
-
 		if (typeof eventData === 'object') {
 			eventData = JSON.stringify(eventData);
 		}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const resolvedPromise = Promise.resolve();
 const listenerAdded = Symbol('listenerAdded');
 const listenerRemoved = Symbol('listenerRemoved');
 
+let globalDebugFlag = false;
+
 function assertEventName(eventName) {
 	if (typeof eventName !== 'string' && typeof eventName !== 'symbol') {
 		throw new TypeError('eventName must be a string or a symbol');
@@ -190,7 +192,11 @@ class Emittery {
 	}
 
 	static get isDebug() {
-		return process.env.DEBUG === 'emittery' || process.env.DEBUG === '*';
+		return process.env.DEBUG === 'emittery' || process.env.DEBUG === '*' || globalDebugFlag;
+	}
+
+	static set isDebug(newValue) {
+		globalDebugFlag = newValue;
 	}
 
 	static debugLogger(type, debugName, eventName, eventData) {

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ class Emittery {
 		assertListener(listener);
 		getListeners(this, eventName).add(listener);
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('subscribe', this.debugName, eventName, null);
+			Emittery.debugLogger('subscribe', this.debugName, eventName, undefined);
 		}
 
 		if (!isListenerSymbol(eventName)) {
@@ -225,7 +225,7 @@ class Emittery {
 		assertListener(listener);
 
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('unsubscribe', this.debugName, eventName, null);
+			Emittery.debugLogger('unsubscribe', this.debugName, eventName, undefined);
 		}
 
 		if (!isListenerSymbol(eventName)) {
@@ -237,7 +237,7 @@ class Emittery {
 
 	once(eventName) {
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('subscribeOnce', this.debugName, eventName, null);
+			Emittery.debugLogger('subscribeOnce', this.debugName, eventName, undefined);
 		}
 
 		return new Promise(resolve => {
@@ -314,7 +314,7 @@ class Emittery {
 	onAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('subscribeAny', this.debugName, null, null);
+			Emittery.debugLogger('subscribeAny', this.debugName, undefined, undefined);
 		}
 
 		anyMap.get(this).add(listener);
@@ -329,7 +329,7 @@ class Emittery {
 	offAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('unsubscribeAny', this.debugName, null, null);
+			Emittery.debugLogger('unsubscribeAny', this.debugName, undefined, undefined);
 		}
 
 		this.emit(listenerRemoved, {listener});
@@ -338,7 +338,7 @@ class Emittery {
 
 	clearListeners(eventName) {
 		if (Emittery.isDebug() || this.isDebug) {
-			Emittery.debugLogger('clear', this.debugName, eventName, null);
+			Emittery.debugLogger('clear', this.debugName, eventName, undefined);
 		}
 
 		if (typeof eventName === 'string') {

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ class Emittery {
 		};
 	}
 
-	static isDebug() {
+	static get isDebug() {
 		return process.env.DEBUG === 'emittery' || process.env.DEBUG === '*';
 	}
 
@@ -221,7 +221,7 @@ class Emittery {
 			assertEventName(eventName);
 			getListeners(this, eventName).add(listener);
 
-			if (Emittery.isDebug() || this.isDebug) {
+			if (Emittery.isDebug || this.isDebug) {
 				Emittery.debugLogger('subscribe', this.debugName, eventName, undefined);
 			}
 
@@ -241,7 +241,7 @@ class Emittery {
 			assertEventName(eventName);
 			getListeners(this, eventName).delete(listener);
 
-			if (Emittery.isDebug() || this.isDebug) {
+			if (Emittery.isDebug || this.isDebug) {
 				Emittery.debugLogger('unsubscribe', this.debugName, eventName, undefined);
 			}
 
@@ -272,7 +272,7 @@ class Emittery {
 	async emit(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug() || this.isDebug) {
+		if (Emittery.isDebug || this.isDebug) {
 			Emittery.debugLogger('emit', this.debugName, eventName, eventData);
 		}
 
@@ -301,7 +301,7 @@ class Emittery {
 	async emitSerial(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug() || this.isDebug) {
+		if (Emittery.isDebug || this.isDebug) {
 			Emittery.debugLogger('emitSerial', this.debugName, eventName, eventData);
 		}
 
@@ -328,7 +328,7 @@ class Emittery {
 
 	onAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug() || this.isDebug) {
+		if (Emittery.isDebug || this.isDebug) {
 			Emittery.debugLogger('subscribeAny', this.debugName, undefined, undefined);
 		}
 
@@ -343,7 +343,7 @@ class Emittery {
 
 	offAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug() || this.isDebug) {
+		if (Emittery.isDebug || this.isDebug) {
 			Emittery.debugLogger('unsubscribeAny', this.debugName, undefined, undefined);
 		}
 
@@ -355,7 +355,7 @@ class Emittery {
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
 
 		for (const eventName of eventNames) {
-			if (Emittery.isDebug() || this.isDebug) {
+			if (Emittery.isDebug || this.isDebug) {
 				Emittery.debugLogger('clear', this.debugName, eventName, undefined);
 			}
 

--- a/index.js
+++ b/index.js
@@ -181,12 +181,21 @@ class Emittery {
 		};
 	}
 
-	static isDebug = process.env.DEBUG === 'emittery' || process.env.DEBUG === '*';
-	static debugLogger = (type, debugName, eventName, eventData) => {
-		if (typeof eventName !== 'string') eventName = eventName.toString();
-		if (typeof eventData === 'object') eventData = JSON.stringify(eventData);
+	static isDebug() {
+		return process.env.DEBUG === 'emittery' || process.env.DEBUG === '*';
+	}
+
+	static debugLogger(type, debugName, eventName, eventData) {
+		if (typeof eventName !== 'string') {
+			eventName = eventName.toString();
+		}
+
+		if (typeof eventData === 'object') {
+			eventData = JSON.stringify(eventData);
+		}
+
 		console.log(`[emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
-	};
+	}
 
 	constructor(options = {}) {
 		anyMap.set(this, new Set());
@@ -200,7 +209,7 @@ class Emittery {
 		assertEventName(eventName);
 		assertListener(listener);
 		getListeners(this, eventName).add(listener);
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug() || this.isDebug) {
 			Emittery.debugLogger('subscribe', this.debugName, eventName, null);
 		}
 
@@ -215,7 +224,7 @@ class Emittery {
 		assertEventName(eventName);
 		assertListener(listener);
 
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug() || this.isDebug) {
 			Emittery.debugLogger('unsubscribe', this.debugName, eventName, null);
 		}
 
@@ -227,9 +236,10 @@ class Emittery {
 	}
 
 	once(eventName) {
-		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('attachOnce', this.debugName, eventName, null);
+		if (Emittery.isDebug() || this.isDebug) {
+			Emittery.debugLogger('subscribeOnce', this.debugName, eventName, null);
 		}
+
 		return new Promise(resolve => {
 			assertEventName(eventName);
 			const off = this.on(eventName, data => {
@@ -247,7 +257,7 @@ class Emittery {
 	async emit(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug() || this.isDebug) {
 			Emittery.debugLogger('emit', this.debugName, eventName, eventData);
 		}
 
@@ -276,9 +286,10 @@ class Emittery {
 	async emitSerial(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug() || this.isDebug) {
 			Emittery.debugLogger('emitSerial', this.debugName, eventName, eventData);
 		}
+
 		const listeners = getListeners(this, eventName);
 		const anyListeners = anyMap.get(this);
 		const staticListeners = [...listeners];
@@ -302,9 +313,10 @@ class Emittery {
 
 	onAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('subscribeAny', this.debugName, eventName, null);
+		if (Emittery.isDebug() || this.isDebug) {
+			Emittery.debugLogger('subscribeAny', this.debugName, null, null);
 		}
+
 		anyMap.get(this).add(listener);
 		this.emit(listenerAdded, {listener});
 		return this.offAny.bind(this, listener);
@@ -316,15 +328,16 @@ class Emittery {
 
 	offAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('unsubscribeAny', this.debugName, eventName, null);
+		if (Emittery.isDebug() || this.isDebug) {
+			Emittery.debugLogger('unsubscribeAny', this.debugName, null, null);
 		}
+
 		this.emit(listenerRemoved, {listener});
 		anyMap.get(this).delete(listener);
 	}
 
 	clearListeners(eventName) {
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug() || this.isDebug) {
 			Emittery.debugLogger('clear', this.debugName, eventName, null);
 		}
 

--- a/index.js
+++ b/index.js
@@ -217,8 +217,7 @@ class Emittery {
 		anyMap.set(this, new Set());
 		eventsMap.set(this, new Map());
 		producersMap.set(this, new Map());
-		this.debug = options.debug || {name: ''};
-		this.isDebug = false;
+		this.debug = options.debug || {name: '', enabled: false};
 	}
 
 	on(eventNames, listener) {
@@ -229,7 +228,7 @@ class Emittery {
 			assertEventName(eventName);
 			getListeners(this, eventName).add(listener);
 
-			if (Emittery.isDebug || this.isDebug) {
+			if (Emittery.isDebug || this.debug.enabled) {
 				this.debugLogger('subscribe', this.debug.name, eventName, undefined);
 			}
 
@@ -249,7 +248,7 @@ class Emittery {
 			assertEventName(eventName);
 			getListeners(this, eventName).delete(listener);
 
-			if (Emittery.isDebug || this.isDebug) {
+			if (Emittery.isDebug || this.debug.enabled) {
 				this.debugLogger('unsubscribe', this.debug.name, eventName, undefined);
 			}
 
@@ -280,7 +279,7 @@ class Emittery {
 	async emit(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug || this.debug.enabled) {
 			this.debugLogger('emit', this.debug.name, eventName, eventData);
 		}
 
@@ -309,7 +308,7 @@ class Emittery {
 	async emitSerial(eventName, eventData) {
 		assertEventName(eventName);
 
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug || this.debug.enabled) {
 			this.debugLogger('emitSerial', this.debug.name, eventName, eventData);
 		}
 
@@ -336,7 +335,7 @@ class Emittery {
 
 	onAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug || this.debug.enabled) {
 			this.debugLogger('subscribeAny', this.debug.name, undefined, undefined);
 		}
 
@@ -351,7 +350,7 @@ class Emittery {
 
 	offAny(listener) {
 		assertListener(listener);
-		if (Emittery.isDebug || this.isDebug) {
+		if (Emittery.isDebug || this.debug.enabled) {
 			this.debugLogger('unsubscribeAny', this.debug.name, undefined, undefined);
 		}
 
@@ -363,7 +362,7 @@ class Emittery {
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
 
 		for (const eventName of eventNames) {
-			if (Emittery.isDebug || this.isDebug) {
+			if (Emittery.isDebug || this.debug.enabled) {
 				this.debugLogger('clear', this.debug.name, eventName, undefined);
 			}
 

--- a/index.js
+++ b/index.js
@@ -199,19 +199,25 @@ class Emittery {
 		globalDebugFlag = newValue;
 	}
 
-	static debugLogger(type, debugName, eventName, eventData) {
+	debugLogger(type, debugName, eventName, eventData) {
 		if (typeof eventData === 'object') {
 			eventData = JSON.stringify(eventData);
 		}
 
-		console.log(`[emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
+		if (typeof eventName === 'symbol') {
+			eventName = eventName.toString();
+		}
+
+		const currentTime = new Date();
+		const logTime = `${currentTime.getHours()}:${currentTime.getMinutes()}:${currentTime.getSeconds()}.${currentTime.getMilliseconds()}`;
+		console.log(`[${logTime}][emittery:${type}][${debugName}] Event Name: ${eventName}\n\tdata: ${eventData}`);
 	}
 
 	constructor(options = {}) {
 		anyMap.set(this, new Set());
 		eventsMap.set(this, new Map());
 		producersMap.set(this, new Map());
-		this.debugName = options.debugName;
+		this.debug = options.debug || {name: ''};
 		this.isDebug = false;
 	}
 
@@ -224,7 +230,7 @@ class Emittery {
 			getListeners(this, eventName).add(listener);
 
 			if (Emittery.isDebug || this.isDebug) {
-				Emittery.debugLogger('subscribe', this.debugName, eventName, undefined);
+				this.debugLogger('subscribe', this.debug.name, eventName, undefined);
 			}
 
 			if (!isListenerSymbol(eventName)) {
@@ -244,7 +250,7 @@ class Emittery {
 			getListeners(this, eventName).delete(listener);
 
 			if (Emittery.isDebug || this.isDebug) {
-				Emittery.debugLogger('unsubscribe', this.debugName, eventName, undefined);
+				this.debugLogger('unsubscribe', this.debug.name, eventName, undefined);
 			}
 
 			if (!isListenerSymbol(eventName)) {
@@ -275,7 +281,7 @@ class Emittery {
 		assertEventName(eventName);
 
 		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('emit', this.debugName, eventName, eventData);
+			this.debugLogger('emit', this.debug.name, eventName, eventData);
 		}
 
 		enqueueProducers(this, eventName, eventData);
@@ -304,7 +310,7 @@ class Emittery {
 		assertEventName(eventName);
 
 		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('emitSerial', this.debugName, eventName, eventData);
+			this.debugLogger('emitSerial', this.debug.name, eventName, eventData);
 		}
 
 		const listeners = getListeners(this, eventName);
@@ -331,7 +337,7 @@ class Emittery {
 	onAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('subscribeAny', this.debugName, undefined, undefined);
+			this.debugLogger('subscribeAny', this.debug.name, undefined, undefined);
 		}
 
 		anyMap.get(this).add(listener);
@@ -346,7 +352,7 @@ class Emittery {
 	offAny(listener) {
 		assertListener(listener);
 		if (Emittery.isDebug || this.isDebug) {
-			Emittery.debugLogger('unsubscribeAny', this.debugName, undefined, undefined);
+			this.debugLogger('unsubscribeAny', this.debug.name, undefined, undefined);
 		}
 
 		this.emit(listenerRemoved, {listener});
@@ -358,7 +364,7 @@ class Emittery {
 
 		for (const eventName of eventNames) {
 			if (Emittery.isDebug || this.isDebug) {
-				Emittery.debugLogger('clear', this.debugName, eventName, undefined);
+				this.debugLogger('clear', this.debug.name, eventName, undefined);
 			}
 
 			if (typeof eventName === 'string' || typeof eventName === 'symbol') {

--- a/index.js
+++ b/index.js
@@ -204,9 +204,6 @@ class Emittery {
 		eventsMap.set(this, new Map());
 		producersMap.set(this, new Map());
 		this.debug = options.debug || {};
-		if (!this.debug.name) {
-			this.debug.name = '';
-		}
 
 		if (this.debug.enabled === undefined) {
 			this.debug.enabled = false;

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ class Emittery {
 		producersMap.set(this, new Map());
 		this.debug = options.debug || {};
 		if (!this.debug.name) {
-			this.debug.name = null;
+			this.debug.name = '';
 		}
 
 		if (this.debug.enabled === undefined) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -68,14 +68,37 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 
 // IsDebug
 {
-	const ee = new Emittery();
+	type MyEventData = {
+		value: string;
+		open: undefined;
+		close: boolean;
+	};
+
+	const ee = new Emittery<MyEventData>();
+
+	const myLogger = (type: string, debugName: string, eventName?: keyof MyEventData, eventData?: MyEventData[keyof MyEventData]): void => {
+		expectAssignable<string>(type);
+		expectAssignable<string>(debugName);
+		expectAssignable<string | undefined>(eventName);
+		expectAssignable<MyEventData[keyof MyEventData]>(eventData);
+	};
+
+	const debugOptions = {name: 'test', enabled: true, logger: myLogger};
+
+	// Global debug flag
 	expectAssignable<boolean>(Emittery.isDebugEnabled);
-	expectAssignable<boolean | undefined>(ee.debug.enabled);
+
+	// General debug options
+	expectAssignable<typeof ee.debug>(debugOptions);
 	expectAssignable<string>(ee.debug.name);
+	expectAssignable<boolean | undefined>(ee.debug.enabled);
+
+	// Debug logger
 	expectNotAssignable<() => undefined>(ee.debug.logger);
 	expectNotAssignable<(data: unknown) => undefined>(ee.debug.logger);
 	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debug.logger);
-	expectAssignable<((type: string, debugName: string, eventName?: string, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
+	expectNotAssignable<((type: string, debugName: string, eventName?: string, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
+	expectAssignable<typeof ee.debug.logger>(myLogger);
 }
 
 // Userland can't emit the meta events

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType, expectError} from 'tsd';
+import {expectType, expectError, expectNotAssignable, expectAssignable} from 'tsd';
 import Emittery = require('.');
 
 // emit
@@ -38,4 +38,15 @@ import Emittery = require('.');
 {
 	const ee = new Emittery();
 	expectError(ee.on('anEvent', (data: any, more: any) => undefined));
+}
+
+// isDebug
+{
+	expectNotAssignable<boolean>(Emittery.isDebug);
+	expectNotAssignable<() => undefined>(Emittery.isDebug);
+	expectAssignable<() => boolean>(Emittery.isDebug);
+	expectNotAssignable<() => undefined>(Emittery.debugLogger);
+	expectNotAssignable<(data: unknown) => undefined>(Emittery.debugLogger);
+	expectNotAssignable<(type: string, debugName: string) => undefined>(Emittery.debugLogger);
+	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: unknown) => void>(Emittery.debugLogger);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -70,10 +70,12 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 {
 	const ee = new Emittery();
 	expectAssignable<boolean>(Emittery.isDebug);
-	expectNotAssignable<() => undefined>(ee.debugLogger);
-	expectNotAssignable<(data: unknown) => undefined>(ee.debugLogger);
-	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debugLogger);
-	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: Record<string, any>) => void>(ee.debugLogger);
+	expectAssignable<boolean | undefined>(ee.debug.enabled);
+	expectAssignable<string>(ee.debug.name);
+	expectNotAssignable<() => undefined>(ee.debug.logger);
+	expectNotAssignable<(data: unknown) => undefined>(ee.debug.logger);
+	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debug.logger);
+	expectAssignable<((type: string, debugName: string, eventName?: string | symbol, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
 }
 
 // Userland can't emit the meta events

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -69,7 +69,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 // IsDebug
 {
 	const ee = new Emittery();
-	expectAssignable<boolean>(Emittery.isDebug);
+	expectAssignable<boolean>(Emittery.isDebugEnabled);
 	expectAssignable<boolean | undefined>(ee.debug.enabled);
 	expectAssignable<string>(ee.debug.name);
 	expectNotAssignable<() => undefined>(ee.debug.logger);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -75,7 +75,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	expectNotAssignable<() => undefined>(ee.debug.logger);
 	expectNotAssignable<(data: unknown) => undefined>(ee.debug.logger);
 	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debug.logger);
-	expectAssignable<((type: string, debugName: string, eventName?: string | symbol, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
+	expectAssignable<((type: string, debugName: string, eventName?: string, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
 }
 
 // Userland can't emit the meta events

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -73,7 +73,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	expectNotAssignable<() => undefined>(ee.debugLogger);
 	expectNotAssignable<(data: unknown) => undefined>(ee.debugLogger);
 	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debugLogger);
-	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: unknown) => void>(ee.debugLogger);
+	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: Record<string, any>) => void>(ee.debugLogger);
 }
 
 // Userland can't emit the meta events

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -42,9 +42,7 @@ import Emittery = require('.');
 
 // isDebug
 {
-	expectNotAssignable<boolean>(Emittery.isDebug);
-	expectNotAssignable<() => undefined>(Emittery.isDebug);
-	expectAssignable<() => boolean>(Emittery.isDebug);
+	expectAssignable<boolean>(Emittery.isDebug);
 	expectNotAssignable<() => undefined>(Emittery.debugLogger);
 	expectNotAssignable<(data: unknown) => undefined>(Emittery.debugLogger);
 	expectNotAssignable<(type: string, debugName: string) => undefined>(Emittery.debugLogger);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -66,13 +66,14 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	expectError(ee.on('anEvent', (data: any, more: any) => undefined));
 }
 
-// isDebug
+// IsDebug
 {
+	const ee = new Emittery();
 	expectAssignable<boolean>(Emittery.isDebug);
-	expectNotAssignable<() => undefined>(Emittery.debugLogger);
-	expectNotAssignable<(data: unknown) => undefined>(Emittery.debugLogger);
-	expectNotAssignable<(type: string, debugName: string) => undefined>(Emittery.debugLogger);
-	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: unknown) => void>(Emittery.debugLogger);
+	expectNotAssignable<() => undefined>(ee.debugLogger);
+	expectNotAssignable<(data: unknown) => undefined>(ee.debugLogger);
+	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debugLogger);
+	expectAssignable<(type: string, debugName: string, eventName?: string | symbol, eventData?: unknown) => void>(ee.debugLogger);
 }
 
 // Userland can't emit the meta events

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,58 @@ Emittery accepts strings and symbols as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
-### emitter = new Emittery()
+### isDebug()
+Controls debug mode for all instances
+
+**Default:** Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
+**Example:**
+```js
+const Emittery = require('emittery');
+Emittery.isDebug = () => true;
+
+const emitter = new Emittery({debugName: 'myEmitter'});
+emitter.on('test', data => { // do something });
+
+//=> [emittery:subscribe][myEmitter] Event Name: test
+//	data: undefined
+```
+
+### debugLogger(type, debugName, eventName, eventData)
+Handles debug data, by default it print it to the console.
+
+**Default:** Prints the type, debugName, eventName and eventData to the console.
+**Example:**
+```js
+const Emittery = require('emittery');
+Emittery.isDebug = () => true;
+Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
+
+const emitter = new Emittery();
+emitter.on('test', data => { // do something });
+
+//=> [subscribe]: test
+```
+
+### emitter = new Emittery(options)
+#### options
+Configure the new instance of Emittery
+
+##### debugName
+Type: `string`
+Default: `undefined`
+
+Define a name for the instance of Emittery to use when outputting debug data.
+Example:
+```js
+const Emittery = require('emittery');
+Emittery.isDebug = () => true;
+
+const emitter = new Emittery({debugName: "myEmitter"});
+emitter.on('test', data => { // do something });
+
+//=> [emittery:subscribe][myEmitter] Event Name: test
+//	data: undefined
+```
 
 #### on(eventName, listener)
 
@@ -244,6 +295,23 @@ const object = {};
 new Emittery().bindMethods(object);
 
 object.emit('event');
+```
+
+#### isDebug
+Type: `boolean`
+Default: `false`
+
+Enables debug output for this instance of Emittery.
+Example:
+```js
+const Emittery = require('emittery');
+
+const emitter = new Emittery({debugName: 'myEmitter'});
+emitter.isDebug = true;
+emitter.on('test', data => { // do something });
+
+//=> [emittery:subscribe][myEmitter] Event Name: test
+//	data: undefined
 ```
 
 ## TypeScript

--- a/readme.md
+++ b/readme.md
@@ -65,15 +65,15 @@ emitter2.on('otherTest', data => { // do something });
 //	data: undefined
 ```
 
-### emitter = new Emittery(?options)
+### emitter = new Emittery(options?)
 
 Create a new instance of Emittery
 
-#### ?options
+#### options?
 
 Configure the new instance of Emittery
 
-##### ?debug
+##### debug?
 
 Configure the debugging options for this instance
 
@@ -153,7 +153,6 @@ emitter.on('test', data => { // do something });
 
 //=> [subscribe]: test
 ```
-*/
 
 
 #### on(eventName | eventName[], listener)

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Type: `string`
 Default: `undefined`
 
 Define a name for the instance of Emittery to use when outputting debug data.
+
 Example:
 ```js
 const Emittery = require('emittery');
@@ -306,6 +307,7 @@ Type: `boolean`
 Default: `false`
 
 Enables debug output for this instance of Emittery.
+
 Example:
 ```js
 const Emittery = require('emittery');

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,8 @@ Emittery accepts strings and symbols as event names.
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
 ### isDebug
-Enables/Disables debug mode for all instances
+
+Toggle debug mode for all instances.
 
 Default: Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
 
@@ -56,32 +57,37 @@ Emittery.isDebug = true;
 
 const emitter1 = new Emittery({debug: {name: 'myEmitter1'}});
 const emitter2 = new Emittery({debug: {name: 'myEmitter2'}});
+
 emitter1.on('test', data => { // do something });
 emitter2.on('otherTest', data => { // do something });
 
+emitter1.emit('test');
+emitter2.emit('otherTest');
+
 //=> [16:43:20.417][emittery:subscribe][myEmitter1] Event Name: test
 //	data: undefined
+
 //=> [16:43:20.417][emittery:subscribe][myEmitter2] Event Name: otherTest
 //	data: undefined
 ```
 
 ### emitter = new Emittery(options?)
 
-Create a new instance of Emittery
+Create a new instance of Emittery.
 
 #### options?
 
-Configure the new instance of Emittery
+Configure the new instance of Emittery.
 
 ##### debug?
 
-Configure the debugging options for this instance
+Configure the debugging options for this instance.
 
 ###### name
 
 Type: `string`
 
-Default: `Empty string`
+Default: `null`
 
 Define a name for the instance of Emittery to use when outputting debug data.
 
@@ -89,8 +95,12 @@ Example:
 ```js
 const Emittery = require('emittery');
 Emittery.isDebug = true;
+
 const emitter = new Emittery({debug: {name: 'myEmitter'}});
 emitter.on('test', data => { // do something });
+
+emitter.emit('test');
+
 //=> [16:43:20.417][emittery:subscribe][myEmitter] Event Name: test
 //	data: undefined
 ```
@@ -101,15 +111,21 @@ Type: `boolean`
 
 Default: `false`
 
-Enable/Disable debug logging just for this instance
+Toggle debug logging just for this instance.
 
 Example:
 ```js
 const Emittery = require('emittery');
+
 const emitter1 = new Emittery({debug: {name: 'emitter1', enabled: true}});
 const emitter2 = new Emittery({debug: {name: 'emitter2'}});
+
 emitter1.on('test', data => { // do something });
 emitter2.on('test', data => { // do something });
+
+emitter1.emit('test');
+emitter2.emit('test');
+
 //=> [16:43:20.417][emittery:subscribe][emitter1] Event Name: test
 //	data: undefined
 ```
@@ -135,7 +151,7 @@ Default:
 }
 ```
 
-Function that handles debug data
+Function that handles debug data.
 
 Example:
 ```js
@@ -149,7 +165,9 @@ const emitter = new Emittery({
 		logger: myLogger
 	}
 });
+
 emitter.on('test', data => { // do something });
+emitter.emit('test');
 
 //=> [subscribe]: test
 ```

--- a/readme.md
+++ b/readme.md
@@ -51,8 +51,10 @@ Toggle debug mode for all instances.
 Default: Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
 
 Example:
+
 ```js
 const Emittery = require('emittery');
+
 Emittery.isDebugEnabled = true;
 
 const emitter1 = new Emittery({debug: {name: 'myEmitter1'}});
@@ -85,15 +87,16 @@ Configure the debugging options for this instance.
 
 ###### name
 
-Type: `string`
-
+Type: `string`\
 Default: `undefined`
 
 Define a name for the instance of Emittery to use when outputting debug data.
 
 Example:
+
 ```js
 const Emittery = require('emittery');
+
 Emittery.isDebugEnabled = true;
 
 const emitter = new Emittery({debug: {name: 'myEmitter'}});
@@ -114,6 +117,7 @@ Default: `false`
 Toggle debug logging just for this instance.
 
 Example:
+
 ```js
 const Emittery = require('emittery');
 
@@ -135,6 +139,7 @@ emitter2.emit('test');
 Type: `Function(string, string, EventName?, Record<string, any>?) => void`
 
 Default:
+
 ```js
 (type, debugName, eventName, eventData) => {
 	if (typeof eventData === 'object') {
@@ -154,8 +159,10 @@ Default:
 Function that handles debug data.
 
 Example:
+
 ```js
 const Emittery = require('emittery');
+
 const myLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
 
 const emitter = new Emittery({
@@ -172,7 +179,6 @@ emitter.emit('test');
 
 //=> [subscribe]: test
 ```
-
 
 #### on(eventName | eventName[], listener)
 

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,8 @@ Configure the debugging options for this instance.
 
 Type: `string`
 
+Default: `undefined`
+
 Define a name for the instance of Emittery to use when outputting debug data.
 
 Example:

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@ const emitter = new Emittery({
 });
 
 emitter.on('test', data => { // do something });
+
 emitter.emit('test');
 
 //=> [subscribe]: test

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ Symbol event names can be used to avoid name collisions when your classes are ex
 Controls debug mode for all instances
 
 **Default:** Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
+
 **Example:**
 ```js
 const Emittery = require('emittery');
@@ -60,9 +61,10 @@ emitter.on('test', data => { // do something });
 ```
 
 ### debugLogger(type, debugName, eventName, eventData)
-Handles debug data, by default it print it to the console.
+Handles debug data.
 
 **Default:** Prints the type, debugName, eventName and eventData to the console.
+
 **Example:**
 ```js
 const Emittery = require('emittery');
@@ -81,6 +83,7 @@ Configure the new instance of Emittery
 
 ##### debugName
 Type: `string`
+
 Default: `undefined`
 
 Define a name for the instance of Emittery to use when outputting debug data.
@@ -299,6 +302,7 @@ object.emit('event');
 
 #### isDebug
 Type: `boolean`
+
 Default: `false`
 
 Enables debug output for this instance of Emittery.

--- a/readme.md
+++ b/readme.md
@@ -87,8 +87,6 @@ Configure the debugging options for this instance.
 
 Type: `string`
 
-Default: `null`
-
 Define a name for the instance of Emittery to use when outputting debug data.
 
 Example:

--- a/readme.md
+++ b/readme.md
@@ -43,15 +43,15 @@ Emittery accepts strings and symbols as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
-### isDebug()
+### isDebug
 Controls debug mode for all instances
 
-**Default:** Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
+Default: Returns true if the DEBUG environment variable is set to 'emittery' or '*', otherwise false.
 
-**Example:**
+Example:
 ```js
 const Emittery = require('emittery');
-Emittery.isDebug = () => true;
+Emittery.isDebug = true;
 
 const emitter = new Emittery({debugName: 'myEmitter'});
 emitter.on('test', data => { // do something });
@@ -63,12 +63,12 @@ emitter.on('test', data => { // do something });
 ### debugLogger(type, debugName, eventName, eventData)
 Handles debug data.
 
-**Default:** Prints the type, debugName, eventName and eventData to the console.
+Default: Prints the type, debugName, eventName and eventData to the console.
 
-**Example:**
+Example:
 ```js
 const Emittery = require('emittery');
-Emittery.isDebug = () => true;
+Emittery.isDebug = true;
 Emittery.debugLogger = (type, debugName, eventName, eventData) => console.log(`[${type}]: ${eventName}`);
 
 const emitter = new Emittery();
@@ -91,7 +91,7 @@ Define a name for the instance of Emittery to use when outputting debug data.
 Example:
 ```js
 const Emittery = require('emittery');
-Emittery.isDebug = () => true;
+Emittery.isDebug = true;
 
 const emitter = new Emittery({debugName: "myEmitter"});
 emitter.on('test', data => { // do something });

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Emittery accepts strings and symbols as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
-### isDebug
+### isDebugEnabled
 
 Toggle debug mode for all instances.
 
@@ -53,7 +53,7 @@ Default: Returns true if the DEBUG environment variable is set to 'emittery' or 
 Example:
 ```js
 const Emittery = require('emittery');
-Emittery.isDebug = true;
+Emittery.isDebugEnabled = true;
 
 const emitter1 = new Emittery({debug: {name: 'myEmitter1'}});
 const emitter2 = new Emittery({debug: {name: 'myEmitter2'}});
@@ -94,7 +94,7 @@ Define a name for the instance of Emittery to use when outputting debug data.
 Example:
 ```js
 const Emittery = require('emittery');
-Emittery.isDebug = true;
+Emittery.isDebugEnabled = true;
 
 const emitter = new Emittery({debug: {name: 'myEmitter'}});
 emitter.on('test', data => { // do something });
@@ -496,7 +496,7 @@ Note that when using `.emitSerial()`, a slow listener will delay invocation of s
 
 Emittery can collect and log debug information.
 
-To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the static `isDebug` variable to true on the Emittery class, or `myEmitter.debug.enabled` on an instance of it for debugging a single instance.
+To enable this feature set the DEBUG environment variable to 'emittery' or '*'. Additionally you can set the static `isDebugEnabled` variable to true on the Emittery class, or `myEmitter.debug.enabled` on an instance of it for debugging a single instance.
 
 See [API](#api) for more details on how debugging works.
 

--- a/test/index.js
+++ b/test/index.js
@@ -105,10 +105,15 @@ test('off() - listenerAdded', t => {
 test('off() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	const off = emitter.on('test', () => {});
 	off();
@@ -181,10 +186,15 @@ test('on() - isDebug logs output', t => {
 	const eventStore = [];
 	const calls = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.on('test', data => calls.push(data));
 	t.true(eventStore.length > 0);
@@ -506,10 +516,15 @@ test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 test('emit() - isDebug logs output', async t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.on('test', () => {});
 	await emitter.emit('test', 'data');
@@ -663,10 +678,15 @@ test('emitSerial() - calls listeners subscribed when emitSerial() was invoked', 
 test('emitSerial() - isDebug logs output', async t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.on('test', () => {});
 	await emitter.emitSerial('test', 'data');
@@ -894,10 +914,15 @@ test('clearListeners() - with event name - clears iterators for that event', asy
 test('clearListeners() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.on('test', () => {});
 	emitter.clearListeners('test');
@@ -910,10 +935,15 @@ test('clearListeners() - isDebug logs output', t => {
 test('onAny() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.onAny(() => {});
 	t.true(eventStore.length > 0);
@@ -925,10 +955,15 @@ test('onAny() - isDebug logs output', t => {
 test('offAny() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: true,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	const off = emitter.onAny(() => {});
 	off();
@@ -1024,7 +1059,7 @@ test('bindMethods() - methodNames must be array of strings or undefined', t => {
 });
 
 test('bindMethods() - must bind all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'debugLogger'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
 
 	const emitter = new Emittery();
 	const target = {};
@@ -1091,7 +1126,7 @@ test('mixin() - methodNames must be array of strings or undefined', t => {
 });
 
 test('mixin() - must mixin all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'debugLogger'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
 
 	class TestClass {}
 
@@ -1133,10 +1168,15 @@ test('isDebug can be turned on globally during runtime', t => {
 	Emittery.isDebug = true;
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: false,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 
 	emitter.on('test', () => {});
 	emitter.emit('test', 'test data');
@@ -1151,11 +1191,16 @@ test('isDebug can be turned on globally during runtime', t => {
 test('isDebug can be turned on for and instance without using the constructor', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	const emitter = new Emittery({
+		debug: {
+			name: 'testEmitter',
+			enabled: false,
+			logger: (type, debugName, eventName, eventData) => {
+				eventStore.push({type, debugName, eventName, eventData});
+			}
+		}
+	});
 	emitter.debug.enabled = true;
-	emitter.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
 
 	emitter.on('test', () => {});
 	emitter.emit('test', 'test data');

--- a/test/index.js
+++ b/test/index.js
@@ -1110,3 +1110,20 @@ test('isDebug default logger handles symbol event names and object for event dat
 	emitter.on(eventName, () => {});
 	await t.notThrowsAsync(emitter.emit(eventName, {complex: ['data', 'structure', 1]}));
 });
+
+test('isDebug can be turned on globally during runtime', t => {
+	Emittery.isDebug = true;
+	const eventStore = [];
+	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+		eventStore.push({type, debugName, eventName, eventData});
+	};
+
+	const emitter = new Emittery({debugName: 'testEmitter'});
+	emitter.on('test', () => {});
+	emitter.emit('test', 'test data');
+	t.true(eventStore.length > 0);
+	t.is(eventStore[2].type, 'emit');
+	t.is(eventStore[2].eventName, 'test');
+	t.is(eventStore[2].debugName, 'testEmitter');
+	t.is(eventStore[2].eventData, 'test data');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -104,12 +104,13 @@ test('off() - listenerAdded', t => {
 
 test('off() - isDebug logs output', t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	const off = emitter.on('test', () => {});
 	off();
 	t.true(eventStore.length > 0);
@@ -180,12 +181,13 @@ test('on() - dedupes identical listeners', async t => {
 test('on() - isDebug logs output', t => {
 	const eventStore = [];
 	const calls = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	emitter.on('test', data => calls.push(data));
 	t.true(eventStore.length > 0);
 	t.is(eventStore[0].type, 'subscribe');
@@ -505,12 +507,14 @@ test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 
 test('emit() - isDebug logs output', async t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	emitter.on('test', () => {});
 	await emitter.emit('test', 'data');
 	t.true(eventStore.length > 0);
@@ -662,12 +666,13 @@ test('emitSerial() - calls listeners subscribed when emitSerial() was invoked', 
 
 test('emitSerial() - isDebug logs output', async t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	emitter.on('test', () => {});
 	await emitter.emitSerial('test', 'data');
 	t.true(eventStore.length > 0);
@@ -893,12 +898,13 @@ test('clearListeners() - with event name - clears iterators for that event', asy
 
 test('clearListeners() - isDebug logs output', t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	emitter.on('test', () => {});
 	emitter.clearListeners('test');
 	t.true(eventStore.length > 0);
@@ -909,12 +915,13 @@ test('clearListeners() - isDebug logs output', t => {
 
 test('onAny() - isDebug logs output', t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	emitter.onAny(() => {});
 	t.true(eventStore.length > 0);
 	t.is(eventStore[0].type, 'subscribeAny');
@@ -924,12 +931,13 @@ test('onAny() - isDebug logs output', t => {
 
 test('offAny() - isDebug logs output', t => {
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.isDebug = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
 	const off = emitter.onAny(() => {});
 	off();
 	t.true(eventStore.length > 0);
@@ -1024,7 +1032,7 @@ test('bindMethods() - methodNames must be array of strings or undefined', t => {
 });
 
 test('bindMethods() - must bind all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'debugLogger'];
 
 	const emitter = new Emittery();
 	const target = {};
@@ -1091,7 +1099,7 @@ test('mixin() - methodNames must be array of strings or undefined', t => {
 });
 
 test('mixin() - must mixin all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'debugLogger'];
 
 	class TestClass {}
 
@@ -1133,13 +1141,15 @@ test('isDebug default logger handles symbol event names and object for event dat
 test('isDebug can be turned on globally during runtime', t => {
 	Emittery.isDebug = true;
 	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
 
-	const emitter = new Emittery({debugName: 'testEmitter'});
 	emitter.on('test', () => {});
 	emitter.emit('test', 'test data');
+	Emittery.isDebug = false;
 	t.true(eventStore.length > 0);
 	t.is(eventStore[2].type, 'emit');
 	t.is(eventStore[2].eventName, 'test');

--- a/test/index.js
+++ b/test/index.js
@@ -359,21 +359,6 @@ test('once() - eventName must be a string or a symbol', async t => {
 	await t.throwsAsync(emitter.once(42), TypeError);
 });
 
-test('once() - isDebug logs output', t => {
-	const eventStore = [];
-	Emittery.debugLogger = (type, debugName, eventName, eventData) => {
-		eventStore.push({type, debugName, eventName, eventData});
-	};
-
-	const emitter = new Emittery({debugName: 'testEmitter'});
-	emitter.isDebug = true;
-	emitter.once('test', () => {});
-	t.true(eventStore.length > 0);
-	t.is(eventStore[0].type, 'subscribeOnce');
-	t.is(eventStore[0].eventName, 'test');
-	t.is(eventStore[0].debugName, 'testEmitter');
-});
-
 test.cb('emit() - one event', t => {
 	t.plan(1);
 

--- a/test/index.js
+++ b/test/index.js
@@ -1059,7 +1059,7 @@ test('bindMethods() - methodNames must be array of strings or undefined', t => {
 });
 
 test('bindMethods() - must bind all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'logIfDebugEnabled'];
 
 	const emitter = new Emittery();
 	const target = {};
@@ -1126,7 +1126,7 @@ test('mixin() - methodNames must be array of strings or undefined', t => {
 });
 
 test('mixin() - must mixin all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'];
+	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'logIfDebugEnabled'];
 
 	class TestClass {}
 
@@ -1165,7 +1165,7 @@ test('isDebug default logger handles symbol event names and object for event dat
 });
 
 test('isDebug can be turned on globally during runtime', t => {
-	Emittery.isDebug = true;
+	Emittery.isDebugEnabled = true;
 	const eventStore = [];
 
 	const emitter = new Emittery({
@@ -1180,7 +1180,7 @@ test('isDebug can be turned on globally during runtime', t => {
 
 	emitter.on('test', () => {});
 	emitter.emit('test', 'test data');
-	Emittery.isDebug = false;
+	Emittery.isDebugEnabled = false;
 	t.true(eventStore.length > 0);
 	t.is(eventStore[2].type, 'emit');
 	t.is(eventStore[2].eventName, 'test');

--- a/test/index.js
+++ b/test/index.js
@@ -1147,3 +1147,21 @@ test('isDebug can be turned on globally during runtime', t => {
 	t.is(eventStore[2].debugName, 'testEmitter');
 	t.is(eventStore[2].eventData, 'test data');
 });
+
+test('isDebug can be turned on for and instance without using the constructor', t => {
+	const eventStore = [];
+
+	const emitter = new Emittery({debug: {name: 'testEmitter'}});
+	emitter.debug.enabled = true;
+	emitter.debugLogger = (type, debugName, eventName, eventData) => {
+		eventStore.push({type, debugName, eventName, eventData});
+	};
+
+	emitter.on('test', () => {});
+	emitter.emit('test', 'test data');
+	t.true(eventStore.length > 0);
+	t.is(eventStore[2].type, 'emit');
+	t.is(eventStore[2].eventName, 'test');
+	t.is(eventStore[2].debugName, 'testEmitter');
+	t.is(eventStore[2].eventData, 'test data');
+});

--- a/test/index.js
+++ b/test/index.js
@@ -729,7 +729,7 @@ test('onAny() - isDebug logs output', t => {
 	emitter.onAny(() => {});
 	t.true(eventStore.length > 0);
 	t.is(eventStore[0].type, 'subscribeAny');
-	t.is(eventStore[0].eventName, null);
+	t.is(eventStore[0].eventName, undefined);
 	t.is(eventStore[0].debugName, 'testEmitter');
 });
 
@@ -745,7 +745,7 @@ test('offAny() - isDebug logs output', t => {
 	off();
 	t.true(eventStore.length > 0);
 	t.is(eventStore[2].type, 'unsubscribeAny');
-	t.is(eventStore[2].eventName, null);
+	t.is(eventStore[2].eventName, undefined);
 	t.is(eventStore[2].debugName, 'testEmitter');
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -105,8 +105,7 @@ test('off() - listenerAdded', t => {
 test('off() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -182,8 +181,7 @@ test('on() - isDebug logs output', t => {
 	const eventStore = [];
 	const calls = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -508,9 +506,7 @@ test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 test('emit() - isDebug logs output', async t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
-
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -667,8 +663,7 @@ test('emitSerial() - calls listeners subscribed when emitSerial() was invoked', 
 test('emitSerial() - isDebug logs output', async t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -899,8 +894,7 @@ test('clearListeners() - with event name - clears iterators for that event', asy
 test('clearListeners() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -916,8 +910,7 @@ test('clearListeners() - isDebug logs output', t => {
 test('onAny() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -932,8 +925,7 @@ test('onAny() - isDebug logs output', t => {
 test('offAny() - isDebug logs output', t => {
 	const eventStore = [];
 
-	const emitter = new Emittery({debug: {name: 'testEmitter'}});
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	emitter.debugLogger = (type, debugName, eventName, eventData) => {
 		eventStore.push({type, debugName, eventName, eventData});
 	};
@@ -1131,8 +1123,7 @@ test('mixin() - target must be function', t => {
 });
 
 test('isDebug default logger handles symbol event names and object for event data', async t => {
-	const emitter = new Emittery();
-	emitter.isDebug = true;
+	const emitter = new Emittery({debug: {name: 'testEmitter', enabled: true}});
 	const eventName = Symbol('test');
 	emitter.on(eventName, () => {});
 	await t.notThrowsAsync(emitter.emit(eventName, {complex: ['data', 'structure', 1]}));


### PR DESCRIPTION
This PR aims to implement a built-in debug feature described in #2
#### How it's implemented
There's a static function in the `Emittery` class called `debugLogger`, that takes in 4 parameters
* type - type of debug log
* debugName - set by the instance of Emittery that generated this log
* eventName - event name related to the log
* eventData - in case of emit, this is the data sent by it

Debugging can be triggered in 3 ways currently:
1. the `DEBUG` environment variable is set to *emittery* or *
2. the static `isDebug` function in Emittery returns true (by default this handles the environment variable, but this function can be overridden, to enable package wide debugging instead of the 3rd method.
3. the `isDebug` variable is set to true on one or more instances.
#### Questions/suggestions
I wasn't sure if the default logger function should include some sort of timestamp.

It might add too much complexity but a verbosity option could be nice. For example currently every emit, subscribe, unsubscribe etc. event is logged, but in some cases they might not all be interesting. Of course this can be achieved by overriding the `debugLogger` function on `Emittery`, but it would be a nice convenience option.

Is it acceptable that there's one static logging function on `Emittery` or should the individual instanced of it be able to override this function. This would add the ability for different instances of `Emittery` to log differently based on their function in an application.

Fixes #2


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2: Built-in debug info](https://issuehunt.io/repos/112248999/issues/2)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->