### PR TITLE
Ensure `.emit()` doesn't return a value

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ class Emittery {
 		const staticAnyListeners = isListenerSymbol(eventName) ? [] : [...anyListeners];
 
 		await resolvedPromise;
-		return Promise.all([
+		await Promise.all([
 			...staticListeners.map(async listener => {
 				if (listeners.has(listener)) {
 					return listener(eventData);

--- a/test/index.js
+++ b/test/index.js
@@ -352,24 +352,28 @@ test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 	t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 });
 
-test('emit() - returns undefined if listeners don’t throw', async t => {
+test('emit() - returns undefined', async t => {
 	const emitter = new Emittery();
-	const listener = () => '🌈';
 
-	emitter.on('🦄', listener);
-
+	emitter.on('🦄', () => '🌈');
 	t.is(await emitter.emit('🦄'), undefined);
+
+	emitter.on('🦄🦄', async () => '🌈');
+	t.is(await emitter.emit('🦄🦄'), undefined);
 });
 
-test('emit() - returns an error if any listener throws', async t => {
+test('emit() - throws an error if any listener throws', async t => {
 	const emitter = new Emittery();
-	const listener = () => {
+
+	emitter.on('🦄', () => {
 		throw new Error('🌈');
-	};
+	});
+	await t.throwsAsync(emitter.emit('🦄'), {instanceOf: Error});
 
-	emitter.on('🦄', listener);
-
-	await t.throwsAsync(emitter.emit('🦄'), Error);
+	emitter.on('🦄🦄', async () => {
+		throw new Error('🌈');
+	});
+	await t.throwsAsync(emitter.emit('🦄🦄'), {instanceOf: Error});
 });
 
 test.cb('emitSerial()', t => {

--- a/test/index.js
+++ b/test/index.js
@@ -352,6 +352,26 @@ test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 	t.deepEqual(calls, [1, 1, 2, 3, 2, 4, 5, 2, 4, 7, 6, 2, 4, 7, 6, 9, 2, 4, 7, 6, 9]);
 });
 
+test('emit() - returns undefined if listeners don’t throw', async t => {
+	const emitter = new Emittery();
+	const listener = () => '🌈';
+
+	emitter.on('🦄', listener);
+
+	t.is(await emitter.emit('🦄'), undefined);
+});
+
+test('emit() - returns an error if any listener throws', async t => {
+	const emitter = new Emittery();
+	const listener = () => {
+		throw new Error('🌈');
+	};
+
+	emitter.on('🦄', listener);
+
+	await t.throwsAsync(emitter.emit('🦄'), Error);
+});
+
 test.cb('emitSerial()', t => {
 	t.plan(1);
 


### PR DESCRIPTION
Fixes #55 

Just replaced the `return` statement and added a couple of tests.