### PR TITLE
Allow async listeners in the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -421,7 +421,7 @@ declare namespace Emittery {
 		/**
 		The listener that was added or removed.
 		*/
-		listener: (eventData?: unknown) => Promise<void>;
+		listener: (eventData?: unknown) => void | Promise<void>;
 
 		/**
 		The name of the event that was added or removed if `.on()` or `.off()` was used, or `undefined` if `.onAny()` or `.offAny()` was used.

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,11 +144,11 @@ declare class Emittery<
 	*/
 	on<Name extends keyof EventData>(
 		eventName: Name,
-		listener: (eventData: EventData[Name]) => void
+		listener: (eventData: EventData[Name]) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 	on(
 		eventName: typeof Emittery.listenerAdded | typeof Emittery.listenerRemoved,
-		listener: (eventData: Emittery.ListenerChangedData) => void
+		listener: (eventData: Emittery.ListenerChangedData) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 
 	/**
@@ -263,7 +263,7 @@ declare class Emittery<
 	*/
 	off<Name extends keyof EventData>(
 		eventName: Name,
-		listener: (eventData: EventData[Name]) => void
+		listener: (eventData: EventData[Name]) => void | Promise<void>
 	): void;
 
 	/**
@@ -328,7 +328,7 @@ declare class Emittery<
 		listener: (
 			eventName: keyof EventData,
 			eventData: EventData[keyof EventData]
-		) => void
+		) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 
 	/**
@@ -376,7 +376,7 @@ declare class Emittery<
 		listener: (
 			eventName: keyof EventData,
 			eventData: EventData[keyof EventData]
-		) => void
+		) => void | Promise<void>
 	): void;
 
 	/**
@@ -421,7 +421,7 @@ declare namespace Emittery {
 		/**
 		The listener that was added or removed.
 		*/
-		listener: (eventData?: unknown) => void;
+		listener: (eventData?: unknown) => Promise<void>;
 
 		/**
 		The name of the event that was added or removed if `.on()` or `.off()` was used, or `undefined` if `.onAny()` or `.offAny()` was used.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -83,6 +83,20 @@ import Emittery = require('.');
 	expectError(ee.on('value', (value: number) => {}));
 }
 
+// Async listeners
+{
+	const ee = new Emittery<{
+		open: undefined;
+		close: string;
+	}>();
+	ee.on('open', () => {});
+	ee.on('open', async () => {});
+	ee.on('open', async () => Promise.resolve());
+	ee.on('close', async value => {
+		expectType<string>(value);
+	});
+}
+
 // Strict typing for onAny, offAny listeners
 {
 	const ee = new Emittery<{

--- a/test/index.js
+++ b/test/index.js
@@ -391,6 +391,21 @@ test.cb('emit() - is async', t => {
 	t.false(unicorn);
 });
 
+test('emit() - awaits async listeners', async t => {
+	const emitter = new Emittery();
+	let unicorn = false;
+
+	emitter.on('🦄', async () => {
+		await Promise.resolve();
+		unicorn = true;
+	});
+
+	const promise = emitter.emit('🦄');
+	t.false(unicorn);
+	await promise;
+	t.true(unicorn);
+});
+
 test('emit() - calls listeners subscribed when emit() was invoked', async t => {
 	const emitter = new Emittery();
 	const calls = [];


### PR DESCRIPTION
This is on top of #69.

Emittery already supports awaiting event emission, which in turn awaits all the listeners that return a Promise. If a caller awaits `emit`, all the listeners will have resolved by the time the outer promise resolves, which is great!

This adds a test for that behaviour, and updates the TypeScript types to support these async listeners. There's no new or changed behaviour.