### PR TITLE
Fix typings compatibility with `p-event`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,11 @@ type DatalessEventNames<EventData> = {
 	[Key in keyof EventData]: EventData[Key] extends undefined ? Key : never;
 }[keyof EventData];
 
+declare const listenerAdded: unique symbol;
+type ListenerAddedSymbol = typeof listenerAdded;
+declare const listenerRemoved: unique symbol;
+type ListenerRemovedSymbol = typeof listenerRemoved;
+
 /**
 Emittery is a strictly typed, fully async EventEmitter implementation. Event listeners can be registered with `on` or `once`, and events can be emitted with `emit`.
 
@@ -43,6 +48,7 @@ emitter.emit('other');
 */
 declare class Emittery<
 	EventData = Record<string, any>, // When https://github.com/microsoft/TypeScript/issues/1863 ships, we can switch this to have an index signature including Symbols. If you want to use symbol keys right now, you need to pass an interface with those symbol keys explicitly listed.
+	ExtendedEventData = EventData & Record<ListenerAddedSymbol | ListenerRemovedSymbol, Emittery.ListenerChangedData>,
 	DatalessEvents = DatalessEventNames<EventData>
 > {
 	/**
@@ -69,7 +75,7 @@ declare class Emittery<
 	});
 	```
 	*/
-	static readonly listenerAdded: unique symbol;
+	static readonly listenerAdded: ListenerAddedSymbol;
 
 	/**
 	Fires when an event listener was removed.
@@ -97,7 +103,7 @@ declare class Emittery<
 	off();
 	```
 	*/
-	static readonly listenerRemoved: unique symbol;
+	static readonly listenerRemoved: ListenerRemovedSymbol;
 
 	/**
 	In TypeScript, it returns a decorator which mixins `Emittery` as property `emitteryPropertyName` and `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the target class.
@@ -143,13 +149,9 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // log => '🍖'
 	```
 	*/
-	on<Name extends keyof EventData>(
+	on<Name extends keyof ExtendedEventData>(
 		eventName: Name,
-		listener: (eventData: EventData[Name]) => void | Promise<void>
-	): Emittery.UnsubscribeFn;
-	on(
-		eventName: typeof Emittery.listenerAdded | typeof Emittery.listenerRemoved,
-		listener: (eventData: Emittery.ListenerChangedData) => void | Promise<void>
+		listener: (eventData: ExtendedEventData[Name]) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 
 	/**
@@ -291,10 +293,7 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // Nothing happens
 	```
 	*/
-	once<Name extends keyof EventData>(eventName: Name): Promise<EventData[Name]>;
-	once(
-		eventName: typeof Emittery.listenerAdded | typeof Emittery.listenerRemoved
-	): Promise<Emittery.ListenerChangedData>;
+	once<Name extends keyof ExtendedEventData>(eventName: Name): Promise<ExtendedEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import {expectType, expectError} from 'tsd';
+import pEvent = require('p-event');
 import Emittery = require('.');
 
 // Emit
@@ -154,6 +155,26 @@ import Emittery = require('.');
 			expectType<string | number>(event[1]);
 		}
 	};
+}
+
+// Compatibility with p-event, without explicit types
+{
+	const ee = new Emittery();
+	pEvent.iterator(ee, 'data', {
+		resolutionEvents: ['finish']
+	});
+}
+
+// Compatibility with p-event, with explicit types
+{
+	const ee = new Emittery<{
+		data: unknown;
+		error: unknown;
+		finish: undefined;
+	}>();
+	pEvent.iterator(ee, 'data', {
+		resolutionEvents: ['finish']
+	});
 }
 
 // Mixin type


### PR DESCRIPTION
With the release of `0.8.0`, the following no longer type-checks:

```ts
import pEvent = require('p-event');

const ee = new Emittery();
pEvent.iterator(ee, 'data', {
	resolutionEvents: ['finish']
});
```

This PR fixes this.