### PR TITLE
fix(types): add array parameter types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -149,7 +149,7 @@ declare class Emittery<
 	```
 	*/
 	on<Name extends keyof AllEventData>(
-		eventName: Name,
+		eventName: Name | Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 
@@ -264,7 +264,7 @@ declare class Emittery<
 	```
 	*/
 	off<Name extends keyof AllEventData>(
-		eventName: Name,
+		eventName: Name | Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): void;
 
@@ -292,7 +292,9 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // Nothing happens
 	```
 	*/
-	once<Name extends keyof AllEventData>(eventName: Name): Promise<AllEventData[Name]>;
+	once<Name extends keyof AllEventData>(
+		eventName: Name | Name[]
+	): Promise<AllEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.

--- a/index.d.ts
+++ b/index.d.ts
@@ -385,12 +385,12 @@ declare class Emittery<
 
 	If `eventName` is given, only the listeners for that event are cleared.
 	*/
-	clearListeners(eventName?: keyof EventData): void;
+	clearListeners<Name extends keyof EventData>(eventName?: Name | Name[]): void;
 
 	/**
 	The number of listeners for the `eventName` or all events if not specified.
 	*/
-	listenerCount(eventName?: keyof EventData): number;
+	listenerCount<Name extends keyof EventData>(eventName?: Name | Name[]): number;
 
 	/**
 	Bind the given `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the `target` object.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -93,6 +93,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 		value: string;
 		open: undefined;
 		close: undefined;
+		other: number;
 	}>();
 	ee.on('open', () => {});
 	ee.on('open', argument => {
@@ -103,6 +104,9 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('value', argument => {
 		expectType<string>(argument);
 	});
+	ee.on(['value', 'other'], argument => {
+		expectType<string | number>(argument);
+	});
 
 	const listener = (value: string) => undefined;
 	ee.on('value', listener);
@@ -110,6 +114,8 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	const test = async () => {
 		const event = await ee.once('value');
 		expectType<string>(event);
+		const firstEvent = await ee.once(['value', 'other']);
+		expectType<string | number>(firstEvent);
 	};
 
 	expectError(ee.on('value', (value: number) => {}));
@@ -195,14 +201,15 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 			value: string;
 			open: undefined;
 			close: undefined;
+			other: number;
 		}>();
 
 		for await (const event of ee.events('value')) {
 			expectType<string>(event);
 		}
 
-		for await (const event of ee.events(['value', 'open'])) {
-			expectType<string | undefined>(event);
+		for await (const event of ee.events(['value', 'other'])) {
+			expectType<string | number>(event);
 		}
 
 		const ee2 = new Emittery();


### PR DESCRIPTION
Add types for methods that can receive a single event name or an array of event names.