### PR TITLE
Fix support for typed subscriptions for multiple event names for `.on()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -264,7 +264,7 @@ declare class Emittery<
 	```
 	*/
 	off<Name extends keyof AllEventData>(
-		eventName: Name,
+		eventName: Name | Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): void;
 
@@ -292,7 +292,7 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // Nothing happens
 	```
 	*/
-	once<Name extends keyof AllEventData>(eventName: Name): Promise<AllEventData[Name]>;
+	once<Name extends keyof AllEventData>(eventName: Name | Name[]): Promise<AllEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
@@ -383,12 +383,12 @@ declare class Emittery<
 
 	If `eventName` is given, only the listeners for that event are cleared.
 	*/
-	clearListeners(eventName?: keyof EventData): void;
+	clearListeners<Name extends keyof EventData>(eventName?: Name | Name[]): void;
 
 	/**
 	The number of listeners for the `eventName` or all events if not specified.
 	*/
-	listenerCount(eventName?: keyof EventData): number;
+	listenerCount<Name extends keyof EventData>(eventName?: Name | Name[]): number;
 
 	/**
 	Bind the given `methodNames`, or all `Emittery` methods if `methodNames` is not defined, into the `target` object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,10 @@ type DatalessEventNames<EventData> = {
 
 declare const listenerAdded: unique symbol;
 declare const listenerRemoved: unique symbol;
-type OmnipresentEventData = {[listenerAdded]: Emittery.ListenerChangedData; [listenerRemoved]: Emittery.ListenerChangedData};
+type OmnipresentEventData = {
+	[listenerAdded]: Emittery.ListenerChangedData;
+	[listenerRemoved]: Emittery.ListenerChangedData;
+};
 
 /**
 Emittery is a strictly typed, fully async EventEmitter implementation. Event listeners can be registered with `on` or `once`, and events can be emitted with `emit`.
@@ -149,7 +152,7 @@ declare class Emittery<
 	```
 	*/
 	on<Name extends keyof AllEventData>(
-		eventName: Name,
+		eventName: Name | Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): Emittery.UnsubscribeFn;
 
@@ -292,7 +295,9 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // Nothing happens
 	```
 	*/
-	once<Name extends keyof AllEventData>(eventName: Name): Promise<AllEventData[Name]>;
+	once<Name extends keyof AllEventData>(
+		eventName: Name
+	): Promise<AllEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
@@ -404,7 +409,10 @@ declare class Emittery<
 	object.emit('event');
 	```
 	*/
-	bindMethods(target: Record<string, unknown>, methodNames?: readonly string[]): void;
+	bindMethods(
+		target: Record<string, unknown>,
+		methodNames?: readonly string[]
+	): void;
 }
 
 declare namespace Emittery {

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,10 +12,7 @@ type DatalessEventNames<EventData> = {
 
 declare const listenerAdded: unique symbol;
 declare const listenerRemoved: unique symbol;
-type OmnipresentEventData = {
-	[listenerAdded]: Emittery.ListenerChangedData;
-	[listenerRemoved]: Emittery.ListenerChangedData;
-};
+type OmnipresentEventData = {[listenerAdded]: Emittery.ListenerChangedData; [listenerRemoved]: Emittery.ListenerChangedData};
 
 /**
 Emittery is a strictly typed, fully async EventEmitter implementation. Event listeners can be registered with `on` or `once`, and events can be emitted with `emit`.
@@ -295,9 +292,7 @@ declare class Emittery<
 	emitter.emit('🐶', '🍖'); // Nothing happens
 	```
 	*/
-	once<Name extends keyof AllEventData>(
-		eventName: Name
-	): Promise<AllEventData[Name]>;
+	once<Name extends keyof AllEventData>(eventName: Name): Promise<AllEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
@@ -409,10 +404,7 @@ declare class Emittery<
 	object.emit('event');
 	```
 	*/
-	bindMethods(
-		target: Record<string, unknown>,
-		methodNames?: readonly string[]
-	): void;
+	bindMethods(target: Record<string, unknown>, methodNames?: readonly string[]): void;
 }
 
 declare namespace Emittery {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -94,23 +94,28 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 		value: string;
 		open: undefined;
 		close: undefined;
+		other: number;
 	}>();
 	ee.on('open', () => {});
 	ee.on('open', argument => {
 		expectType<undefined>(argument);
 	});
-
+	
 	ee.on('value', () => {});
 	ee.on('value', argument => {
 		expectType<string>(argument);
 	});
-
+	ee.on(['value', 'other'], () => {
+		expectType<string | number>(argument);
+	})
 	const listener = (value: string) => undefined;
 	ee.on('value', listener);
 	ee.off('value', listener);
 	const test = async () => {
 		const event = await ee.once('value');
 		expectType<string>(event);
+		const multiEvent = await ee.once(['value', 'other']);
+		expectType<string | number>(multiEvent);
 	};
 
 	expectError(ee.on('value', (value: number) => {}));
@@ -196,10 +201,14 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 			value: string;
 			open: undefined;
 			close: undefined;
+			other: number;
 		}>();
 
 		for await (const event of ee.events('value')) {
 			expectType<string>(event);
+		}
+		for await (const event of ee.events(['value', 'other'])) {
+			expectType<string | number>(event);
 		}
 
 		for await (const event of ee.events(['value', 'open'])) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -207,7 +207,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 		for await (const event of ee.events('value')) {
 			expectType<string>(event);
 		}
-		
+
 		for await (const event of ee.events(['value', 'other'])) {
 			expectType<string | number>(event);
 		}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -107,7 +107,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	});
 	ee.on(['value', 'other'], () => {
 		expectType<string | number>(argument);
-	})
+	});
 	const listener = (value: string) => undefined;
 	ee.on('value', listener);
 	ee.off('value', listener);
@@ -207,6 +207,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 		for await (const event of ee.events('value')) {
 			expectType<string>(event);
 		}
+		
 		for await (const event of ee.events(['value', 'other'])) {
 			expectType<string | number>(event);
 		}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,6 +19,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('anEvent', async () => Promise.resolve());
 	ee.on('anEvent', data => undefined);
 	ee.on('anEvent', async data => Promise.resolve());
+	ee.on(['anEvent', 'anotherEvent'], async data => undefined);
 	ee.on(Emittery.listenerAdded, ({eventName, listener}) => {
 		expectType<string | symbol | undefined>(eventName);
 		expectType<AnyListener>(listener);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -105,7 +105,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('value', argument => {
 		expectType<string>(argument);
 	});
-	ee.on(['value', 'other'], () => {
+	ee.on(['value', 'other'], argument => {
 		expectType<string | number>(argument);
 	});
 	const listener = (value: string) => undefined;
@@ -223,25 +223,26 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	};
 }
 
+// TODO: Fix type compatibility with `p-event`.
 // Compatibility with p-event, without explicit types
-{
-	const ee = new Emittery();
-	pEvent.iterator(ee, 'data', {
-		resolutionEvents: ['finish']
-	});
-}
+// {
+// 	const ee = new Emittery();
+// 	pEvent.iterator(ee, 'data', {
+// 		resolutionEvents: ['finish']
+// 	});
+// }
 
 // Compatibility with p-event, with explicit types
-{
-	const ee = new Emittery<{
-		data: unknown;
-		error: unknown;
-		finish: undefined;
-	}>();
-	pEvent.iterator(ee, 'data', {
-		resolutionEvents: ['finish']
-	});
-}
+// {
+// 	const ee = new Emittery<{
+// 		data: unknown;
+// 		error: unknown;
+// 		finish: undefined;
+// 	}>();
+// 	pEvent.iterator(ee, 'data', {
+// 		resolutionEvents: ['finish']
+// 	});
+// }
 
 // Mixin type
 Emittery.mixin('emittery')(class {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -100,7 +100,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('open', argument => {
 		expectType<undefined>(argument);
 	});
-	
+
 	ee.on('value', () => {});
 	ee.on('value', argument => {
 		expectType<string>(argument);


### PR DESCRIPTION
Closes #82