### PR TITLE
Allow event names to be numbers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-redeclare */
 
 /**
-Emittery accepts strings and symbols as event names.
+Emittery accepts strings, symbols, and numbers as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 */
-type EventName = string | symbol;
+type EventName = string | symbol | number;
 
 // Helper type for turning the passed `EventData` type map into a list of string keys that don't require data alongside the event name when emitting. Uses the same trick that `Omit` does internally to filter keys by building a map of keys to keys we want to keep, and then accessing all the keys to return just the list of keys we want to keep.
 type DatalessEventNames<EventData> = {
@@ -90,7 +90,7 @@ interface DebugOptions<EventData> {
 	(type, debugName, eventName, eventData) => {
 		eventData = JSON.stringify(eventData);
 
-		if (typeof eventName === 'symbol') {
+		if (typeof eventName === 'symbol' || typeof eventName === 'number') {
 			eventName = eventName.toString();
 		}
 
@@ -142,7 +142,7 @@ Emittery is a strictly typed, fully async EventEmitter implementation. Event lis
 import Emittery = require('emittery');
 
 const emitter = new Emittery<
-	// Pass `{[eventName: <string | symbol>]: undefined | <eventArg>}` as the first type argument for events that pass data to their listeners.
+	// Pass `{[eventName: <string | symbol | number>]: undefined | <eventArg>}` as the first type argument for events that pass data to their listeners.
 	// A value of `undefined` in this map means the event listeners should expect no data, and a type other than `undefined` means the listeners will receive one argument of that type.
 	{
 		open: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 /**
 Emittery accepts strings, symbols, and numbers as event names.
 
-Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
+Symbol event names are preferred given that they can be used to avoid name collisions when your classes are extended, especially for internal events.
 */
 type EventName = PropertyKey;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ Emittery accepts strings, symbols, and numbers as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 */
-type EventName = string | symbol | number;
+type EventName = PropertyKey;
 
 // Helper type for turning the passed `EventData` type map into a list of string keys that don't require data alongside the event name when emitting. Uses the same trick that `Omit` does internally to filter keys by building a map of keys to keys we want to keep, and then accessing all the keys to return just the list of keys we want to keep.
 type DatalessEventNames<EventData> = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,7 +164,7 @@ emitter.emit('other');
 ```
 */
 declare class Emittery<
-	EventData = Record<string, any>, // When https://github.com/microsoft/TypeScript/issues/1863 ships, we can switch this to have an index signature including Symbols. If you want to use symbol keys right now, you need to pass an interface with those symbol keys explicitly listed.
+	EventData = Record<EventName, any>,
 	AllEventData = EventData & _OmnipresentEventData,
 	DatalessEvents = DatalessEventNames<EventData>
 > {

--- a/index.js
+++ b/index.js
@@ -11,9 +11,13 @@ const listenerRemoved = Symbol('listenerRemoved');
 
 let isGlobalDebugEnabled = false;
 
-function assertEventName(eventName) {
+function assertEventName(eventName, allowMetaEvents = false) {
 	if (typeof eventName !== 'string' && typeof eventName !== 'symbol' && typeof eventName !== 'number') {
-		throw new TypeError('eventName must be a string, symbol, or number');
+		throw new TypeError('`eventName` must be a string, symbol, or number');
+	}
+
+	if (isListenerSymbol(eventName) && !allowMetaEvents) {
+		throw new TypeError('`eventName` cannot be meta event `listenerAdded` or `listenerRemoved`');
 	}
 }
 
@@ -245,13 +249,13 @@ class Emittery {
 
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
 		for (const eventName of eventNames) {
-			assertEventName(eventName);
+			assertEventName(eventName, true);
 			getListeners(this, eventName).add(listener);
 
 			this.logIfDebugEnabled('subscribe', eventName, undefined);
 
 			if (!isListenerSymbol(eventName)) {
-				this.emit(listenerAdded, {eventName, listener});
+				this.emit(listenerAdded, {eventName, listener}, true);
 			}
 		}
 
@@ -263,13 +267,13 @@ class Emittery {
 
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
 		for (const eventName of eventNames) {
-			assertEventName(eventName);
+			assertEventName(eventName, true);
 			getListeners(this, eventName).delete(listener);
 
 			this.logIfDebugEnabled('unsubscribe', eventName, undefined);
 
 			if (!isListenerSymbol(eventName)) {
-				this.emit(listenerRemoved, {eventName, listener});
+				this.emit(listenerRemoved, {eventName, listener}, true);
 			}
 		}
 	}
@@ -286,14 +290,14 @@ class Emittery {
 	events(eventNames) {
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
 		for (const eventName of eventNames) {
-			assertEventName(eventName);
+			assertEventName(eventName, true);
 		}
 
 		return iterator(this, eventNames);
 	}
 
-	async emit(eventName, eventData) {
-		assertEventName(eventName);
+	async emit(eventName, eventData, allowMetaEvents) {
+		assertEventName(eventName, allowMetaEvents);
 
 		this.logIfDebugEnabled('emit', eventName, eventData);
 
@@ -319,8 +323,8 @@ class Emittery {
 		]);
 	}
 
-	async emitSerial(eventName, eventData) {
-		assertEventName(eventName);
+	async emitSerial(eventName, eventData, allowMetaEvents) {
+		assertEventName(eventName, allowMetaEvents);
 
 		this.logIfDebugEnabled('emitSerial', eventName, eventData);
 
@@ -351,7 +355,7 @@ class Emittery {
 		this.logIfDebugEnabled('subscribeAny', undefined, undefined);
 
 		anyMap.get(this).add(listener);
-		this.emit(listenerAdded, {listener});
+		this.emit(listenerAdded, {listener}, true);
 		return this.offAny.bind(this, listener);
 	}
 
@@ -364,7 +368,7 @@ class Emittery {
 
 		this.logIfDebugEnabled('unsubscribeAny', undefined, undefined);
 
-		this.emit(listenerRemoved, {listener});
+		this.emit(listenerRemoved, {listener}, true);
 		anyMap.get(this).delete(listener);
 	}
 
@@ -414,7 +418,7 @@ class Emittery {
 			}
 
 			if (typeof eventName !== 'undefined') {
-				assertEventName(eventName);
+				assertEventName(eventName, true);
 			}
 
 			count += anyMap.get(this).size;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const producersMap = new WeakMap();
 const anyProducer = Symbol('anyProducer');
 const resolvedPromise = Promise.resolve();
 
-// Define symbols for meta events.
+// Define symbols for "meta" events.
 const listenerAdded = Symbol('listenerAdded');
 const listenerRemoved = Symbol('listenerRemoved');
 
@@ -20,7 +20,7 @@ function assertEventName(eventName, allowMetaEvents) {
 		throw new TypeError('`eventName` must be a string, symbol, or number');
 	}
 
-	if (isListenerSymbol(eventName) && allowMetaEvents !== metaEventsAllowed) {
+	if (isMetaEvent(eventName) && allowMetaEvents !== metaEventsAllowed) {
 		throw new TypeError('`eventName` cannot be meta event `listenerAdded` or `listenerRemoved`');
 	}
 }
@@ -155,7 +155,7 @@ function defaultMethodNamesOrAssert(methodNames) {
 	return methodNames;
 }
 
-const isListenerSymbol = symbol => symbol === listenerAdded || symbol === listenerRemoved;
+const isMetaEvent = eventName => eventName === listenerAdded || eventName === listenerRemoved;
 
 class Emittery {
 	static mixin(emitteryPropertyName, methodNames) {
@@ -258,7 +258,7 @@ class Emittery {
 
 			this.logIfDebugEnabled('subscribe', eventName, undefined);
 
-			if (!isListenerSymbol(eventName)) {
+			if (!isMetaEvent(eventName)) {
 				this.emit(listenerAdded, {eventName, listener}, metaEventsAllowed);
 			}
 		}
@@ -276,7 +276,7 @@ class Emittery {
 
 			this.logIfDebugEnabled('unsubscribe', eventName, undefined);
 
-			if (!isListenerSymbol(eventName)) {
+			if (!isMetaEvent(eventName)) {
 				this.emit(listenerRemoved, {eventName, listener}, metaEventsAllowed);
 			}
 		}
@@ -310,7 +310,7 @@ class Emittery {
 		const listeners = getListeners(this, eventName);
 		const anyListeners = anyMap.get(this);
 		const staticListeners = [...listeners];
-		const staticAnyListeners = isListenerSymbol(eventName) ? [] : [...anyListeners];
+		const staticAnyListeners = isMetaEvent(eventName) ? [] : [...anyListeners];
 
 		await resolvedPromise;
 		await Promise.all([

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const listenerRemoved = Symbol('listenerRemoved');
 let isGlobalDebugEnabled = false;
 
 function assertEventName(eventName) {
-	if (typeof eventName !== 'string' && typeof eventName !== 'symbol') {
-		throw new TypeError('eventName must be a string or a symbol');
+	if (typeof eventName !== 'string' && typeof eventName !== 'symbol' && typeof eventName !== 'number') {
+		throw new TypeError('eventName must be a string, symbol, or number');
 	}
 }
 
@@ -33,7 +33,7 @@ function getListeners(instance, eventName) {
 }
 
 function getEventProducers(instance, eventName) {
-	const key = typeof eventName === 'string' || typeof eventName === 'symbol' ? eventName : anyProducer;
+	const key = typeof eventName === 'string' || typeof eventName === 'symbol' || typeof eventName === 'number' ? eventName : anyProducer;
 	const producers = producersMap.get(instance);
 	if (!producers.has(key)) {
 		producers.set(key, new Set());
@@ -223,7 +223,7 @@ class Emittery {
 					eventData = `Object with the following keys failed to stringify: ${Object.keys(eventData).join(',')}`;
 				}
 
-				if (typeof eventName === 'symbol') {
+				if (typeof eventName === 'symbol' || typeof eventName === 'number') {
 					eventName = eventName.toString();
 				}
 
@@ -374,7 +374,7 @@ class Emittery {
 		for (const eventName of eventNames) {
 			this.logIfDebugEnabled('clear', eventName, undefined);
 
-			if (typeof eventName === 'string' || typeof eventName === 'symbol') {
+			if (typeof eventName === 'string' || typeof eventName === 'symbol' || typeof eventName === 'number') {
 				getListeners(this, eventName).clear();
 
 				const producers = getEventProducers(this, eventName);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,11 +21,11 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('anEvent', async data => Promise.resolve());
 	ee.on(['anEvent', 'anotherEvent'], async data => undefined);
 	ee.on(Emittery.listenerAdded, ({eventName, listener}) => {
-		expectType<string | symbol | number | undefined>(eventName);
+		expectType<PropertyKey | undefined>(eventName);
 		expectType<AnyListener>(listener);
 	});
 	ee.on(Emittery.listenerRemoved, ({eventName, listener}) => {
-		expectType<string | symbol | number | undefined>(eventName);
+		expectType<PropertyKey | undefined>(eventName);
 		expectType<AnyListener>(listener);
 	});
 }
@@ -47,11 +47,11 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	const test = async () => {
 		await ee.once('anEvent');
 		await ee.once(Emittery.listenerAdded).then(({eventName, listener}) => {
-			expectType<string | symbol | number | undefined>(eventName);
+			expectType<PropertyKey | undefined>(eventName);
 			expectType<AnyListener>(listener);
 		});
 		await ee.once(Emittery.listenerRemoved).then(({eventName, listener}) => {
-			expectType<string | symbol | number | undefined>(eventName);
+			expectType<PropertyKey | undefined>(eventName);
 			expectType<AnyListener>(listener);
 		});
 	};

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -102,13 +102,6 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	expectAssignable<typeof ee.debug.logger>(myLogger);
 }
 
-// Userland can't emit the meta events
-{
-	const ee = new Emittery();
-	expectError(ee.emit(Emittery.listenerRemoved));
-	expectError(ee.emit(Emittery.listenerAdded));
-}
-
 // Strict typing for emission
 {
 	const ee = new Emittery<{

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,11 +21,11 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('anEvent', async data => Promise.resolve());
 	ee.on(['anEvent', 'anotherEvent'], async data => undefined);
 	ee.on(Emittery.listenerAdded, ({eventName, listener}) => {
-		expectType<string | symbol | undefined>(eventName);
+		expectType<string | symbol | number | undefined>(eventName);
 		expectType<AnyListener>(listener);
 	});
 	ee.on(Emittery.listenerRemoved, ({eventName, listener}) => {
-		expectType<string | symbol | undefined>(eventName);
+		expectType<string | symbol | number | undefined>(eventName);
 		expectType<AnyListener>(listener);
 	});
 }
@@ -47,11 +47,11 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	const test = async () => {
 		await ee.once('anEvent');
 		await ee.once(Emittery.listenerAdded).then(({eventName, listener}) => {
-			expectType<string | symbol | undefined>(eventName);
+			expectType<string | symbol | number | undefined>(eventName);
 			expectType<AnyListener>(listener);
 		});
 		await ee.once(Emittery.listenerRemoved).then(({eventName, listener}) => {
-			expectType<string | symbol | undefined>(eventName);
+			expectType<string | symbol | number | undefined>(eventName);
 			expectType<AnyListener>(listener);
 		});
 	};

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ emitter.emit(myUnicorn, '🦋');  // Will trigger printing 'Unicorns love 🦋'
 
 ### eventName
 
-Emittery accepts strings and symbols as event names.
+Emittery accepts strings, symbols, and numbers as event names.
 
 Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
 
@@ -160,7 +160,7 @@ Default:
 		eventData = JSON.stringify(eventData);
 	}
 
-	if (typeof eventName === 'symbol') {
+	if (typeof eventName === 'symbol' || typeof eventName === 'number') {
 		eventName = eventName.toString();
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ emitter.emit(myUnicorn, '🦋');  // Will trigger printing 'Unicorns love 🦋'
 
 Emittery accepts strings, symbols, and numbers as event names.
 
-Symbol event names can be used to avoid name collisions when your classes are extended, especially for internal events.
+Symbol event names are preferred given that they can be used to avoid name collisions when your classes are extended, especially for internal events.
 
 ### isDebugEnabled
 

--- a/readme.md
+++ b/readme.md
@@ -222,7 +222,7 @@ emitter.emit('🐶', '🍖'); // log => '🍖'
 
 ##### Custom subscribable events
 
-Emittery exports some symbols which represent custom events that can be passed to `Emitter.on` and similar methods.
+Emittery exports some symbols which represent "meta" events that can be passed to `Emitter.on` and similar methods.
 
 - `Emittery.listenerAdded` - Fires when an event listener was added.
 - `Emittery.listenerRemoved` - Fires when an event listener was removed.

--- a/test/index.js
+++ b/test/index.js
@@ -133,14 +133,15 @@ test('on() - listenerAdded offAny', async t => {
 	t.is(eventName, undefined);
 });
 
-test('on() - eventName must be a string or a symbol', t => {
+test('on() - eventName must be a string, symbol, or number', t => {
 	const emitter = new Emittery();
 
 	emitter.on('string', () => {});
 	emitter.on(Symbol('symbol'), () => {});
+	emitter.on(42, () => {});
 
 	t.throws(() => {
-		emitter.on(42, () => {});
+		emitter.on(true, () => {});
 	}, TypeError);
 });
 
@@ -327,14 +328,15 @@ test('off() - multiple event names', async t => {
 	t.deepEqual(calls, [1, 1]);
 });
 
-test('off() - eventName must be a string or a symbol', t => {
+test('off() - eventName must be a string, symbol, or number', t => {
 	const emitter = new Emittery();
 
 	emitter.on('string', () => {});
 	emitter.on(Symbol('symbol'), () => {});
+	emitter.on(42, () => {});
 
 	t.throws(() => {
-		emitter.off(42);
+		emitter.off(true);
 	}, TypeError);
 });
 
@@ -362,13 +364,14 @@ test('once() - multiple event names', async t => {
 	t.is(await promise, fixture);
 });
 
-test('once() - eventName must be a string or a symbol', async t => {
+test('once() - eventName must be a string, symbol, or number', async t => {
 	const emitter = new Emittery();
 
 	emitter.once('string');
 	emitter.once(Symbol('symbol'));
+	emitter.once(42);
 
-	await t.throwsAsync(emitter.once(42), TypeError);
+	await t.throwsAsync(emitter.once(true), TypeError);
 });
 
 test.cb('emit() - one event', t => {
@@ -407,13 +410,14 @@ test.cb('emit() - multiple events', t => {
 	emitter.emit('🦄');
 });
 
-test('emit() - eventName must be a string or a symbol', async t => {
+test('emit() - eventName must be a string, symbol, or number', async t => {
 	const emitter = new Emittery();
 
 	emitter.emit('string');
 	emitter.emit(Symbol('symbol'));
+	emitter.emit(42);
 
-	await t.throwsAsync(emitter.emit(42), TypeError);
+	await t.throwsAsync(emitter.emit(true), TypeError);
 });
 
 test.cb('emit() - is async', t => {
@@ -584,13 +588,14 @@ test.cb('emitSerial()', t => {
 	emitter.emitSerial('🦄', 'e');
 });
 
-test('emitSerial() - eventName must be a string or a symbol', async t => {
+test('emitSerial() - eventName must be a string, symbol, or number', async t => {
 	const emitter = new Emittery();
 
 	emitter.emitSerial('string');
 	emitter.emitSerial(Symbol('symbol'));
+	emitter.emitSerial(42);
 
-	await t.throwsAsync(emitter.emitSerial(42), TypeError);
+	await t.throwsAsync(emitter.emitSerial(true), TypeError);
 });
 
 test.cb('emitSerial() - is async', t => {
@@ -1002,15 +1007,16 @@ test('listenerCount() - works with empty eventName strings', t => {
 	t.is(emitter.listenerCount(''), 1);
 });
 
-test('listenerCount() - eventName must be undefined if not a string nor a symbol', t => {
+test('listenerCount() - eventName must be undefined if not a string, symbol, or number', t => {
 	const emitter = new Emittery();
 
 	emitter.listenerCount('string');
 	emitter.listenerCount(Symbol('symbol'));
+	emitter.listenerCount(42);
 	emitter.listenerCount();
 
 	t.throws(() => {
-		emitter.listenerCount(42);
+		emitter.listenerCount(true);
 	}, TypeError);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -420,6 +420,13 @@ test('emit() - eventName must be a string, symbol, or number', async t => {
 	await t.throwsAsync(emitter.emit(true), TypeError);
 });
 
+test('emit() - userland cannot emit the meta events', async t => {
+	const emitter = new Emittery();
+
+	await t.throwsAsync(emitter.emit(Emittery.listenerRemoved), TypeError);
+	await t.throwsAsync(emitter.emit(Emittery.listenerAdded), TypeError);
+});
+
 test.cb('emit() - is async', t => {
 	t.plan(2);
 
@@ -596,6 +603,13 @@ test('emitSerial() - eventName must be a string, symbol, or number', async t => 
 	emitter.emitSerial(42);
 
 	await t.throwsAsync(emitter.emitSerial(true), TypeError);
+});
+
+test('emitSerial() - userland cannot emit the meta events', async t => {
+	const emitter = new Emittery();
+
+	await t.throwsAsync(emitter.emitSerial(Emittery.listenerRemoved), TypeError);
+	await t.throwsAsync(emitter.emitSerial(Emittery.listenerAdded), TypeError);
 });
 
 test.cb('emitSerial() - is async', t => {


### PR DESCRIPTION
Hi 👋

I'd like to use emittery to model the packets sent between a client and server. All packets are identified by a "type", which is a number. Therefore I was hoping to use emittery in the following way:

```ts
enum ServerPacketType {
  LOGIN_FAILED = 3,
  CHAT = 17,
  SYNC_CLOCK = 30
}

interface ServerPacketEvents {
  [ServerPacketType.LOGIN_FAILED]: [reason: string];
  [ServerPacketType.CHAT]: [from: number, message: string];
  [ServerPacketType.SYNC_CLOCK]: [time: number];
}

const emitter = new Emittery<ServerPacketEvents>();
emitter.on(ServerPacketType.LOGIN_FAILED, ([reason]) => {
  console.log('Login failed!', reason);
});
```

This actually compiles fine, there's no type error. But at runtime an error is thrown here:

https://github.com/sindresorhus/emittery/blob/3cf4a0a2c9344d0ab0d1f1f23957e3bbde98f617/index.js#L14-L18

Maybe I'm missing something crucial here, but I don't see any harm in supporting numbers for event names? So I prepared this PR which does just that. Let me know what you think.

Thanks.