### PR TITLE
Made formatting compatible with prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+	"singleQuote": true,
+	"bracketSpacing": false,
+	"editorconfig": true,
+	"printWidth": 120,
+	"arrowParens": "avoid",
+	"trailingComma": "es5"
+}

--- a/examples/emitonce.js
+++ b/examples/emitonce.js
@@ -4,7 +4,8 @@ import Emittery from '../index.js';
 const myEmitter = new Emittery();
 
 // Register listener for only the one event
-(async () => { // eslint-disable-line unicorn/prefer-top-level-await
+// eslint-disable-next-line unicorn/prefer-top-level-await
+(async () => {
 	console.log('An event occurred (#%d).', await myEmitter.once('event'));
 })();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,12 @@ To enable this feature set the `DEBUG` environment variable to `emittery` or `*`
 
 See API for more information on how debugging works.
 */
-export type DebugLogger<EventData, Name extends keyof EventData> = (type: string, debugName: string, eventName?: Name, eventData?: EventData[Name]) => void;
+export type DebugLogger<EventData, Name extends keyof EventData> = (
+	type: string,
+	debugName: string,
+	eventName?: Name,
+	eventData?: EventData[Name]
+) => void;
 
 /**
 Configure debug options of an instance.
@@ -151,7 +156,7 @@ export type ListenerChangedData = {
 	/**
 	The listener that was added or removed.
 	*/
-	listener: (eventData?: unknown) => (void | Promise<void>);
+	listener: (eventData?: unknown) => void | Promise<void>;
 
 	/**
 	The name of the event that was added or removed if `.on()` or `.off()` was used, or `undefined` if `.onAny()` or `.offAny()` was used.
@@ -427,9 +432,7 @@ export default class Emittery<
 		});
 	```
 	*/
-	events<Name extends keyof EventData>(
-		eventName: Name | readonly Name[]
-	): AsyncIterableIterator<EventData[Name]>;
+	events<Name extends keyof EventData>(eventName: Name | readonly Name[]): AsyncIterableIterator<EventData[Name]>;
 
 	/**
 	Remove one or more event subscriptions.
@@ -493,10 +496,7 @@ export default class Emittery<
 	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
 	*/
 	emit<Name extends DatalessEvents>(eventName: Name): Promise<void>;
-	emit<Name extends keyof EventData>(
-		eventName: Name,
-		eventData: EventData[Name]
-	): Promise<void>;
+	emit<Name extends keyof EventData>(eventName: Name, eventData: EventData[Name]): Promise<void>;
 
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
@@ -506,10 +506,7 @@ export default class Emittery<
 	@returns A promise that resolves when all the event listeners are done.
 	*/
 	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<void>;
-	emitSerial<Name extends keyof EventData>(
-		eventName: Name,
-		eventData: EventData[Name]
-	): Promise<void>;
+	emitSerial<Name extends keyof EventData>(eventName: Name, eventData: EventData[Name]): Promise<void>;
 
 	/**
 	Subscribe to be notified about any event.
@@ -517,10 +514,7 @@ export default class Emittery<
 	@returns A method to unsubscribe.
 	*/
 	onAny(
-		listener: (
-			eventName: keyof EventData,
-			eventData: EventData[keyof EventData]
-		) => void | Promise<void>
+		listener: (eventName: keyof EventData, eventData: EventData[keyof EventData]) => void | Promise<void>
 	): UnsubscribeFunction;
 
 	/**
@@ -557,19 +551,12 @@ export default class Emittery<
 		});
 	```
 	*/
-	anyEvent(): AsyncIterableIterator<
-	[keyof EventData, EventData[keyof EventData]]
-	>;
+	anyEvent(): AsyncIterableIterator<[keyof EventData, EventData[keyof EventData]]>;
 
 	/**
 	Remove an `onAny` subscription.
 	*/
-	offAny(
-		listener: (
-			eventName: keyof EventData,
-			eventData: EventData[keyof EventData]
-		) => void | Promise<void>
-	): void;
+	offAny(listener: (eventName: keyof EventData, eventData: EventData[keyof EventData]) => void | Promise<void>): void;
 
 	/**
 	Clear all event listeners on the instance.

--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ function getListeners(instance, eventName) {
 }
 
 function getEventProducers(instance, eventName) {
-	const key = typeof eventName === 'string' || typeof eventName === 'symbol' || typeof eventName === 'number' ? eventName : anyProducer;
+	const key =
+		typeof eventName === 'string' || typeof eventName === 'symbol' || typeof eventName === 'number'
+			? eventName
+			: anyProducer;
 	const producers = producersMap.get(instance);
 	if (!producers.has(key)) {
 		return;
@@ -127,9 +130,7 @@ function iterator(instance, eventNames) {
 
 			flush();
 
-			return arguments.length > 0
-				? {done: true, value: await value}
-				: {done: true};
+			return arguments.length > 0 ? {done: true, value: await value} : {done: true};
 		},
 
 		[Symbol.asyncIterator]() {
@@ -200,9 +201,10 @@ export default class Emittery {
 				get: getEmitteryProperty,
 			});
 
-			const emitteryMethodCaller = methodName => function (...args) {
-				return this[emitteryPropertyName][methodName](...args);
-			};
+			const emitteryMethodCaller = methodName =>
+				function (...args) {
+					return this[emitteryPropertyName][methodName](...args);
+				};
 
 			for (const methodName of methodNames) {
 				Object.defineProperty(target.prototype, methodName, {
@@ -472,10 +474,11 @@ export default class Emittery {
 
 		for (const eventName of eventNames) {
 			if (typeof eventName === 'string') {
-				count += anyMap.get(this).size
-					+ (getListeners(this, eventName)?.size ?? 0)
-					+ (getEventProducers(this, eventName)?.size ?? 0)
-					+ (getEventProducers(this)?.size ?? 0);
+				count +=
+					anyMap.get(this).size +
+					(getListeners(this, eventName)?.size ?? 0) +
+					(getEventProducers(this, eventName)?.size ?? 0) +
+					(getEventProducers(this)?.size ?? 0);
 
 				continue;
 			}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -80,7 +80,12 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 
 	const ee = new Emittery<MyEventData>();
 
-	const myLogger = (type: string, debugName: string, eventName?: keyof MyEventData, eventData?: MyEventData[keyof MyEventData]): void => {
+	const myLogger = (
+		type: string,
+		debugName: string,
+		eventName?: keyof MyEventData,
+		eventData?: MyEventData[keyof MyEventData]
+	): void => {
 		expectAssignable<string>(type);
 		expectAssignable<string>(debugName);
 		expectAssignable<string | undefined>(eventName);
@@ -101,7 +106,9 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	expectNotAssignable<() => undefined>(ee.debug.logger);
 	expectNotAssignable<(data: unknown) => undefined>(ee.debug.logger);
 	expectNotAssignable<(type: string, debugName: string) => undefined>(ee.debug.logger);
-	expectNotAssignable<((type: string, debugName: string, eventName?: string, eventData?: Record<string, any>) => void) | undefined>(ee.debug.logger);
+	expectNotAssignable<
+		((type: string, debugName: string, eventName?: string, eventData?: Record<string, any>) => void) | undefined
+	>(ee.debug.logger);
 	expectAssignable<typeof ee.debug.logger>(myLogger);
 }
 
@@ -276,11 +283,17 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 // }
 
 // Mixin type
-Emittery.mixin('emittery')(class {
-	test() {}
-});
+Emittery.mixin('emittery')(
+	class {
+		test() {}
+	}
+);
 
 // Mixin type - arguments in constructor
-Emittery.mixin('emittery')(class { // eslint-disable-line @typescript-eslint/no-extraneous-class
-	constructor(argument: string) {} // eslint-disable-line @typescript-eslint/no-useless-constructor
-});
+Emittery.mixin('emittery')(
+	// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+	class {
+		// eslint-disable-next-line @typescript-eslint/no-useless-constructor
+		constructor(argument: string) {}
+	}
+);

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
 			"lcov",
 			"text"
 		]
+	},
+	"xo" : {
+		"prettier": true
 	}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -141,17 +141,23 @@ test('on() - eventName must be a string, symbol, or number', t => {
 	emitter.on(Symbol('symbol'), () => {});
 	emitter.on(42, () => {});
 
-	t.throws(() => {
-		emitter.on(true, () => {});
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.on(true, () => {});
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('on() - must have a listener', t => {
 	const emitter = new Emittery();
 
-	t.throws(() => {
-		emitter.on('🦄');
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.on('🦄');
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('on() - returns a unsubcribe method', async t => {
@@ -336,17 +342,23 @@ test('off() - eventName must be a string, symbol, or number', t => {
 	emitter.on(Symbol('symbol'), () => {});
 	emitter.on(42, () => {});
 
-	t.throws(() => {
-		emitter.off(true);
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.off(true);
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('off() - no listener', t => {
 	const emitter = new Emittery();
 
-	t.throws(() => {
-		emitter.off('🦄');
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.off('🦄');
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('off() - clears global maps when all listeners are removed', t => {
@@ -764,9 +776,12 @@ test('onAny()', async t => {
 test('onAny() - must have a listener', t => {
 	const emitter = new Emittery();
 
-	t.throws(() => {
-		emitter.onAny();
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.onAny();
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test.serial('anyEvent()', async t => {
@@ -779,7 +794,10 @@ test.serial('anyEvent()', async t => {
 	}, 10);
 
 	t.plan(3);
-	const expected = [['🦄', '🌈'], ['🦄', '🌟']];
+	const expected = [
+		['🦄', '🌈'],
+		['🦄', '🌟'],
+	];
 	for await (const data of iterator) {
 		t.deepEqual(data, expected.shift());
 		if (expected.length === 0) {
@@ -841,9 +859,12 @@ test('offAny()', async t => {
 test('offAny() - no listener', t => {
 	const emitter = new Emittery();
 
-	t.throws(() => {
-		emitter.offAny();
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.offAny();
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('clearListeners()', async t => {
@@ -1059,9 +1080,12 @@ test('listenerCount() - eventName must be undefined if not a string, symbol, or 
 	emitter.listenerCount(42);
 	emitter.listenerCount();
 
-	t.throws(() => {
-		emitter.listenerCount(true);
-	}, {instanceOf: TypeError});
+	t.throws(
+		() => {
+			emitter.listenerCount(true);
+		},
+		{instanceOf: TypeError}
+	);
 });
 
 test('bindMethods()', t => {
@@ -1109,7 +1133,21 @@ test('bindMethods() - methodNames must be array of strings or undefined', t => {
 });
 
 test('bindMethods() - must bind all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'logIfDebugEnabled'];
+	const methodsExpected = [
+		'on',
+		'off',
+		'once',
+		'events',
+		'emit',
+		'emitSerial',
+		'onAny',
+		'anyEvent',
+		'offAny',
+		'clearListeners',
+		'listenerCount',
+		'bindMethods',
+		'logIfDebugEnabled',
+	];
 
 	const emitter = new Emittery();
 	const target = {};
@@ -1169,7 +1207,18 @@ test('mixin()', t => {
 		}
 	}
 
-	const TestClassWithMixin = Emittery.mixin('emitter', ['on', 'off', 'once', 'emit', 'emitSerial', 'onAny', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods'])(TestClass);
+	const TestClassWithMixin = Emittery.mixin('emitter', [
+		'on',
+		'off',
+		'once',
+		'emit',
+		'emitSerial',
+		'onAny',
+		'offAny',
+		'clearListeners',
+		'listenerCount',
+		'bindMethods',
+	])(TestClass);
 	const symbol = Symbol('test symbol');
 	const instance = new TestClassWithMixin(symbol);
 	t.true(instance.emitter instanceof Emittery);
@@ -1208,13 +1257,30 @@ test('mixin() - methodNames must be array of strings or undefined', t => {
 });
 
 test('mixin() - must mixin all methods if no array supplied', t => {
-	const methodsExpected = ['on', 'off', 'once', 'events', 'emit', 'emitSerial', 'onAny', 'anyEvent', 'offAny', 'clearListeners', 'listenerCount', 'bindMethods', 'logIfDebugEnabled'];
+	const methodsExpected = [
+		'on',
+		'off',
+		'once',
+		'events',
+		'emit',
+		'emitSerial',
+		'onAny',
+		'anyEvent',
+		'offAny',
+		'clearListeners',
+		'listenerCount',
+		'bindMethods',
+		'logIfDebugEnabled',
+	];
 
 	class TestClass {}
 
 	const TestClassWithMixin = Emittery.mixin('emitter')(TestClass);
 
-	t.deepEqual(Object.getOwnPropertyNames(TestClassWithMixin.prototype).sort(), [...methodsExpected, 'constructor', 'emitter'].sort());
+	t.deepEqual(
+		Object.getOwnPropertyNames(TestClassWithMixin.prototype).sort(),
+		[...methodsExpected, 'constructor', 'emitter'].sort()
+	);
 });
 
 test('mixin() - methodNames must only include Emittery methods', t => {


### PR DESCRIPTION
This change adds a .prettierrc file with settings that best match the existing code style, and it reformets existing files with prettier. Some `eslint-ignore-line` comments were also changed to use `eslint-ignore-next-line` to avoid problems caused by formatting.