### PR TITLE
fix: added narrowed typing to anyEvent iterator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -558,7 +558,9 @@ export default class Emittery<
 	```
 	*/
 	anyEvent(): AsyncIterableIterator<
-	[keyof EventData, EventData[keyof EventData]]
+	{ 
+		[K in keyof EventData]: [K, EventData[K]]
+	}[keyof EventData]
 	>;
 
 	/**


### PR DESCRIPTION
Made it so that the type of data is inferred within the anyEvent iterator