### PR TITLE
feat(breaking): return errors instead of `throw`ing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -495,7 +495,10 @@ export default class Emittery<
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
-	@returns A promise that resolves with `undefined` when all event listeners complete successfully, or resolves with an array of errors if any listeners throw/reject. This promise will never throw. *Done* means the function has executed if synchronous, or resolved if it returns a promise. You usually don't need to await this promise, but you could use it to catch errors. Even if some listeners throw/reject, all listeners will still execute normally.
+	@returns A promise that resolves when all event listeners are done:
+	- If all listeners succeed, resolves with undefined
+	- If any listeners fail, resolves with an array of their errors
+	All listeners will execute regardless of whether other listeners throw/reject.
 	*/
 	emit<Name extends DatalessEvents>(eventName: Name): Promise<EmitResult>;
 	emit<Name extends keyof EventData>(
@@ -506,15 +509,16 @@ export default class Emittery<
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
 
-	If any of the listeners throw/reject, the returned promise will be rejected with the error and the remaining listeners will *not* be called.
-
-	@returns A promise that resolves when all the event listeners are done.
+	@returns A promise that resolves when all event listeners are done:
+	- If all listeners succeed, resolves with undefined
+	- If any listeners fail, resolves with an array of their errors
+	All listeners will execute regardless of whether other listeners throw/reject.
 	*/
-	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<void>;
+	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<EmitResult>;
 	emitSerial<Name extends keyof EventData>(
 		eventName: Name,
 		eventData: EventData[Name]
-	): Promise<void>;
+	): Promise<EmitResult>;
 
 	/**
 	Subscribe to be notified about any event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -515,11 +515,11 @@ export default class Emittery<
 	- If all listeners succeed, resolves with undefined
 	- If any listeners fail, resolves with an array with exactly one error
 	*/
-	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<[unknown]>;
+	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<undefined | [unknown]>;
 	emitSerial<Name extends keyof EventData>(
 		eventName: Name,
 		eventData: EventData[Name]
-	): Promise<[unknown]>;
+	): Promise<undefined | [unknown]>;
 
 	/**
 	Subscribe to be notified about any event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -509,16 +509,17 @@ export default class Emittery<
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
 
+	If any of the listeners throw/reject, the remaining listeners will *not* be called.
+
 	@returns A promise that resolves when all event listeners are done:
 	- If all listeners succeed, resolves with undefined
-	- If any listeners fail, resolves with an array of their errors
-	All listeners will execute regardless of whether other listeners throw/reject.
+	- If any listeners fail, resolves with an array with exactly one error
 	*/
-	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<EmitResult>;
+	emitSerial<Name extends DatalessEvents>(eventName: Name): Promise<[unknown]>;
 	emitSerial<Name extends keyof EventData>(
 		eventName: Name,
 		eventData: EventData[Name]
-	): Promise<EmitResult>;
+	): Promise<[unknown]>;
 
 	/**
 	Subscribe to be notified about any event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,6 +190,11 @@ emitter.emit('open', 1);
 emitter.emit('other');
 ```
 */
+
+export type EmitErrorResult = [unknown, ...unknown[]];
+export type EmitSuccessResult = undefined;
+export type EmitResult = EmitErrorResult | EmitSuccessResult;
+
 export default class Emittery<
 	EventData = Record<EventName, any>, // TODO: Use `unknown` instead of `any`.
 	AllEventData = EventData & OmnipresentEventData,
@@ -492,11 +497,11 @@ export default class Emittery<
 
 	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
 	*/
-	emit<Name extends DatalessEvents>(eventName: Name): Promise<void>;
+	emit<Name extends DatalessEvents>(eventName: Name): Promise<EmitResult>;
 	emit<Name extends keyof EventData>(
 		eventName: Name,
 		eventData: EventData[Name]
-	): Promise<void>;
+	): Promise<EmitResult>;
 
 	/**
 	Same as `emit()`, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.

--- a/index.d.ts
+++ b/index.d.ts
@@ -495,7 +495,7 @@ export default class Emittery<
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
-	@returns A promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
+	@returns A promise that resolves with `undefined` when all event listeners complete successfully, or resolves with an array of errors if any listeners throw/reject. This promise will never throw. *Done* means the function has executed if synchronous, or resolved if it returns a promise. You usually don't need to await this promise, but you could use it to catch errors. Even if some listeners throw/reject, all listeners will still execute normally.
 	*/
 	emit<Name extends DatalessEvents>(eventName: Name): Promise<EmitResult>;
 	emit<Name extends keyof EventData>(

--- a/index.js
+++ b/index.js
@@ -407,19 +407,36 @@ export default class Emittery {
 		const staticAnyListeners = [...anyListeners];
 
 		await resolvedPromise;
+
+		const errors = [];
+
 		/* eslint-disable no-await-in-loop */
 		for (const listener of staticListeners) {
 			if (listeners.has(listener)) {
-				await listener(eventData);
+				try {
+					await listener(eventData);
+				} catch (error) {
+					errors.push(error);
+				}
 			}
 		}
 
 		for (const listener of staticAnyListeners) {
 			if (anyListeners.has(listener)) {
-				await listener(eventName, eventData);
+				try {
+					await listener(eventName, eventData);
+				} catch (error) {
+					errors.push(error);
+				}
 			}
 		}
 		/* eslint-enable no-await-in-loop */
+
+		if (errors.length > 0) {
+			return errors;
+		}
+
+		return undefined;
 	}
 
 	onAny(listener) {

--- a/index.js
+++ b/index.js
@@ -408,15 +408,13 @@ export default class Emittery {
 
 		await resolvedPromise;
 
-		const errors = [];
-
 		/* eslint-disable no-await-in-loop */
 		for (const listener of staticListeners) {
 			if (listeners.has(listener)) {
 				try {
 					await listener(eventData);
 				} catch (error) {
-					errors.push(error);
+					return [error];
 				}
 			}
 		}
@@ -426,15 +424,11 @@ export default class Emittery {
 				try {
 					await listener(eventName, eventData);
 				} catch (error) {
-					errors.push(error);
+					return [error];
 				}
 			}
 		}
 		/* eslint-enable no-await-in-loop */
-
-		if (errors.length > 0) {
-			return errors;
-		}
 
 		return undefined;
 	}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,5 @@
 			"lcov",
 			"text"
 		]
-	},
-	"packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
 			"lcov",
 			"text"
 		]
-	}
+	},
+	"packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/readme.md
+++ b/readme.md
@@ -391,13 +391,13 @@ iterator
 
 Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
-Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. If any of the listeners throw/reject, the returned promise will resolve with an array containing the errors. If all listeners succeed, the promise resolves with `undefined`.
+Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
 
 #### emitSerial(eventName, data?)
 
-Same as above, but it waits for each listener to resolve before triggering the next one. This can be useful if your events depend on each other. Although ideally they should not. Prefer `emit()` whenever possible.
+Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added and executed serially.
 
-If any of the listeners throw/reject, the returned promise will be rejected with the error and the remaining listeners will *not* be called.
+Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. If any of the listeners throw/reject, the returned promise will resolve with an array containing the errors. If all listeners succeed, the promise resolves with `undefined`.
 
 #### onAny(listener)
 

--- a/readme.md
+++ b/readme.md
@@ -388,16 +388,15 @@ iterator
 ```
 
 #### emit(eventName, data?)
-
 Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
-Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
+Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will resolve with an array containing all the errors. All listeners will execute regardless of whether other listeners throw/reject.
 
 #### emitSerial(eventName, data?)
 
 Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added and executed serially.
 
-Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. If any of the listeners throw/reject, the returned promise will resolve with an array containing the errors. If all listeners succeed, the promise resolves with `undefined`.
+Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. If any of the listeners throw/reject, the returned promise will resolve with an array containing exactly one error and remaining listeners will not be called. If all listeners succeed, the promise resolves with `undefined`.
 
 #### onAny(listener)
 

--- a/readme.md
+++ b/readme.md
@@ -391,7 +391,7 @@ iterator
 
 Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.
 
-Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. You usually wouldn't want to wait for this, but you could for example catch possible errors. If any of the listeners throw/reject, the returned promise will be rejected with the error, but the other listeners will not be affected.
+Returns a promise that resolves when all the event listeners are done. *Done* meaning executed if synchronous or resolved when an async/promise-returning function. If any of the listeners throw/reject, the returned promise will resolve with an array containing the errors. If all listeners succeed, the promise resolves with `undefined`.
 
 #### emitSerial(eventName, data?)
 

--- a/test/index.js
+++ b/test/index.js
@@ -1348,3 +1348,32 @@ test('emit() - returns array of errors when listeners fail', async t => {
 	t.is(result[0], syncError);
 	t.is(result[1], asyncError);
 });
+
+test('emitSerial() - returns undefined when all listeners succeed', async t => {
+	const emitter = new Emittery();
+
+	emitter.on('test', () => {});
+	emitter.on('test', async () => {});
+
+	const result = await emitter.emitSerial('test', 'data');
+	t.is(result, undefined);
+});
+
+test('emitSerial() - returns array of errors when listeners fail', async t => {
+	const emitter = new Emittery();
+	const syncError = new Error('sync error');
+	const asyncError = new Error('async error');
+
+	emitter.on('test', () => {
+		throw syncError;
+	});
+	emitter.on('test', async () => {
+		throw asyncError;
+	});
+
+	const result = await emitter.emitSerial('test', 'data');
+	t.true(Array.isArray(result));
+	t.is(result.length, 2);
+	t.is(result[0], syncError);
+	t.is(result[1], asyncError);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1320,7 +1320,7 @@ test('debug mode - handles circular references in event data', async t => {
 	await t.notThrowsAsync(emitter.emit('test', data));
 });
 
-test('emit() - returns null when all listeners succeed', async t => {
+test('emit() - returns undefined when all listeners succeed', async t => {
 	const emitter = new Emittery();
 
 	emitter.on('test', () => {});

--- a/test/index.js
+++ b/test/index.js
@@ -1359,7 +1359,7 @@ test('emitSerial() - returns undefined when all listeners succeed', async t => {
 	t.is(result, undefined);
 });
 
-test('emitSerial() - returns array of errors when listeners fail', async t => {
+test('emitSerial() - returns array of the error when listeners fail', async t => {
 	const emitter = new Emittery();
 	const syncError = new Error('sync error');
 	const asyncError = new Error('async error');
@@ -1373,7 +1373,6 @@ test('emitSerial() - returns array of errors when listeners fail', async t => {
 
 	const result = await emitter.emitSerial('test', 'data');
 	t.true(Array.isArray(result));
-	t.is(result.length, 2);
+	t.is(result.length, 1);
 	t.is(result[0], syncError);
-	t.is(result[1], asyncError);
 });


### PR DESCRIPTION
Closes #51 

Quick PR to showcase https://github.com/sindresorhus/emittery/issues/51#issuecomment-2508028271


> Hey, I just found this old thread while thinking of adopting emittery.
> 
> Would it make sense for `emit()` to never throw and instead return `Promise<null | [unknown, ...unknown]>`?
> 
> ```ts
> import Emittery from 'emittery';
> 
> const emitter = new Emittery<{
>   '🦄': string;
> }>();
> 
> emitter.on('🦄', () => {
>   // works
> });
> 
> emitter.on('🦄', () => {
>   throw new Error('💣');
> });
> 
> const result = await emitter.emit('🦄', 'a');
> 
> if (result) {
>   // result would be [Error('💣')]
>   console.error('Errors', result);
> } else {
>   console.log('all OK!');
> }
> ```

