### PR TITLE
Add support for `AbortController`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -341,7 +341,8 @@ export default class Emittery<
 	*/
 	on<Name extends keyof AllEventData>(
 		eventName: Name | readonly Name[],
-		listener: (eventData: AllEventData[Name]) => void | Promise<void>
+		listener: (eventData: AllEventData[Name]) => void | Promise<void>,
+		options?: {signal?: AbortSignal}
 	): UnsubscribeFunction;
 
 	/**
@@ -520,7 +521,8 @@ export default class Emittery<
 		listener: (
 			eventName: keyof EventData,
 			eventData: EventData[keyof EventData]
-		) => void | Promise<void>
+		) => void | Promise<void>,
+		options?: {signal?: AbortSignal}
 	): UnsubscribeFunction;
 
 	/**

--- a/index.js
+++ b/index.js
@@ -418,9 +418,7 @@ export default class Emittery {
 		emitMetaEvent(this, listenerAdded, {listener});
 		const offAny = this.offAny.bind(this, listener);
 
-		if (options?.signal instanceof globalThis.AbortSignal) {
-			options.signal.addEventListener('abort', offAny);
-		}
+		options?.signal?.addEventListener('abort', offAny);
 
 		return offAny;
 	}

--- a/index.js
+++ b/index.js
@@ -295,9 +295,16 @@ export default class Emittery {
 			}
 		}
 
-		const off = this.off.bind(this, eventNames, listener);
+		const off = () => {
+			this.off(eventNames, listener);
+			options?.signal?.removeEventListener('abort', off);
+		};
 
 		options?.signal?.addEventListener('abort', off);
+
+		if (options?.signal?.aborted) {
+			off();
+		}
 
 		return off;
 	}
@@ -416,9 +423,17 @@ export default class Emittery {
 
 		anyMap.get(this).add(listener);
 		emitMetaEvent(this, listenerAdded, {listener});
-		const offAny = this.offAny.bind(this, listener);
+
+		const offAny = () => {
+			this.offAny(listener);
+			options?.signal?.removeEventListener('abort', offAny);
+		};
 
 		options?.signal?.addEventListener('abort', offAny);
+
+		if (options?.signal?.aborted) {
+			offAny();
+		}
 
 		return offAny;
 	}

--- a/index.js
+++ b/index.js
@@ -297,9 +297,7 @@ export default class Emittery {
 
 		const off = this.off.bind(this, eventNames, listener);
 
-		if (options?.signal instanceof globalThis.AbortSignal) {
-			options.signal.addEventListener('abort', off);
-		}
+		options?.signal?.addEventListener('abort', off);
 
 		return off;
 	}

--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ export default class Emittery {
 		}
 	}
 
-	on(eventNames, listener, options) {
+	on(eventNames, listener, {signal} = {}) {
 		assertListener(listener);
 
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];

--- a/index.js
+++ b/index.js
@@ -297,12 +297,12 @@ export default class Emittery {
 
 		const off = () => {
 			this.off(eventNames, listener);
-			options?.signal?.removeEventListener('abort', off);
+			signal?.removeEventListener('abort', off);
 		};
 
-		options?.signal?.addEventListener('abort', off, {once: true});
+		signal?.addEventListener('abort', off, {once: true});
 
-		if (options?.signal?.aborted) {
+		if (signal?.aborted) {
 			off();
 		}
 
@@ -416,7 +416,7 @@ export default class Emittery {
 		/* eslint-enable no-await-in-loop */
 	}
 
-	onAny(listener, options) {
+	onAny(listener, {signal} = {}) {
 		assertListener(listener);
 
 		this.logIfDebugEnabled('subscribeAny', undefined, undefined);
@@ -426,12 +426,12 @@ export default class Emittery {
 
 		const offAny = () => {
 			this.offAny(listener);
-			options?.signal?.removeEventListener('abort', offAny);
+			signal?.removeEventListener('abort', offAny);
 		};
 
-		options?.signal?.addEventListener('abort', offAny);
+		signal?.addEventListener('abort', offAny, {once: true});
 
-		if (options?.signal?.aborted) {
+		if (signal?.aborted) {
 			offAny();
 		}
 

--- a/index.js
+++ b/index.js
@@ -273,7 +273,7 @@ export default class Emittery {
 		}
 	}
 
-	on(eventNames, listener) {
+	on(eventNames, listener, options) {
 		assertListener(listener);
 
 		eventNames = Array.isArray(eventNames) ? eventNames : [eventNames];
@@ -295,7 +295,13 @@ export default class Emittery {
 			}
 		}
 
-		return this.off.bind(this, eventNames, listener);
+		const off = this.off.bind(this, eventNames, listener);
+
+		if (options?.signal instanceof globalThis.AbortSignal) {
+			options.signal.addEventListener('abort', off);
+		}
+
+		return off;
 	}
 
 	off(eventNames, listener) {
@@ -405,14 +411,20 @@ export default class Emittery {
 		/* eslint-enable no-await-in-loop */
 	}
 
-	onAny(listener) {
+	onAny(listener, options) {
 		assertListener(listener);
 
 		this.logIfDebugEnabled('subscribeAny', undefined, undefined);
 
 		anyMap.get(this).add(listener);
 		emitMetaEvent(this, listenerAdded, {listener});
-		return this.offAny.bind(this, listener);
+		const offAny = this.offAny.bind(this, listener);
+
+		if (options?.signal instanceof globalThis.AbortSignal) {
+			options.signal.addEventListener('abort', offAny);
+		}
+
+		return offAny;
 	}
 
 	anyEvent() {

--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ export default class Emittery {
 			options?.signal?.removeEventListener('abort', off);
 		};
 
-		options?.signal?.addEventListener('abort', off);
+		options?.signal?.addEventListener('abort', off, {once: true});
 
 		if (options?.signal?.aborted) {
 			off();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,6 +19,7 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 	ee.on('anEvent', async () => {});
 	ee.on('anEvent', data => undefined);
 	ee.on('anEvent', async data => {});
+	ee.on('anEvent', async data => {}, {signal: new AbortController().signal});
 	ee.on(['anEvent', 'anotherEvent'], async data => undefined);
 	ee.on(Emittery.listenerAdded, ({eventName, listener}) => {
 		expectType<PropertyKey | undefined>(eventName);
@@ -179,6 +180,8 @@ type AnyListener = (eventData?: unknown) => void | Promise<void>;
 		expectType<'value' | 'open' | 'close' | 'other'>(name);
 		expectType<string | number | undefined>(data);
 	});
+
+	ee.onAny(() => {}, {signal: new AbortController().signal});
 
 	const listener = (name: string) => {};
 	ee.onAny(listener);

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ emitter.emit('test');
 //=> [subscribe]: test
 ```
 
-#### on(eventName | eventName[], listener, options?: { signal?: AbortSignal })
+#### on(eventName | eventName[], listener, options?: {signal?: AbortSignal})
 
 Subscribe to one or more events.
 
@@ -229,7 +229,7 @@ const abortController = new AbortController();
 
 emitter.on('🐗', data => {
 	console.log(data);
-}, { signal: abortController.signal });
+}, {signal: abortController.signal});
 
 abortController.abort();
 emitter.emit('🐗', '🍞'); // nothing happens
@@ -412,7 +412,7 @@ Same as above, but it waits for each listener to resolve before triggering the n
 
 If any of the listeners throw/reject, the returned promise will be rejected with the error and the remaining listeners will *not* be called.
 
-#### onAny(listener, options?: { signal?: AbortSignal })
+#### onAny(listener, options?: {signal?: AbortSignal})
 
 Subscribe to be notified about any event.
 

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ emitter.emit('test');
 //=> [subscribe]: test
 ```
 
-#### on(eventName | eventName[], listener)
+#### on(eventName | eventName[], listener, options?: { signal?: AbortSignal })
 
 Subscribe to one or more events.
 
@@ -220,6 +220,19 @@ emitter.on(['🦄', '🐶'], data => {
 
 emitter.emit('🦄', '🌈'); // log => '🌈' x2
 emitter.emit('🐶', '🍖'); // log => '🍖'
+```
+
+You can pass an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to unsubscribe too:
+
+```js
+const abortController = new AbortController();
+
+emitter.on('🐗', data => {
+	console.log(data);
+}, { signal: abortController.signal });
+
+abortController.abort();
+emitter.emit('🐗', '🍞'); // nothing happens
 ```
 
 ##### Custom subscribable events
@@ -399,11 +412,11 @@ Same as above, but it waits for each listener to resolve before triggering the n
 
 If any of the listeners throw/reject, the returned promise will be rejected with the error and the remaining listeners will *not* be called.
 
-#### onAny(listener)
+#### onAny(listener, options?: { signal?: AbortSignal })
 
 Subscribe to be notified about any event.
 
-Returns a method to unsubscribe.
+Returns a method to unsubscribe. Abort signal is respected too.
 
 ##### listener(eventName, data)
 

--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,8 @@ emitter.emit('🐶', '🍖'); // log => '🍖'
 You can pass an [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to unsubscribe too:
 
 ```js
+import Emittery from 'emittery';
+
 const abortController = new AbortController();
 
 emitter.on('🐗', data => {

--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,26 @@ test('on() - isDebug logs output', t => {
 	t.is(eventStore[0].eventName, 'test');
 });
 
+test('on() - use abort signal', async t => {
+	const emitter = new Emittery();
+	const abortController = new AbortController();
+
+	const calls = [];
+	const listener = () => {
+		calls.push(1);
+	};
+
+	emitter.on('abc', listener, {signal: abortController.signal});
+
+	await emitter.emit('abc');
+	t.deepEqual(calls, [1]);
+
+	abortController.abort();
+	await emitter.emit('abc');
+
+	t.deepEqual(calls, [1]);
+});
+
 test.serial('events()', async t => {
 	const emitter = new Emittery();
 	const iterator = emitter.events('🦄');
@@ -767,6 +787,24 @@ test('onAny() - must have a listener', t => {
 	t.throws(() => {
 		emitter.onAny();
 	}, {instanceOf: TypeError});
+});
+
+test('onAny() - use abort signal', async t => {
+	t.plan(4);
+
+	const emitter = new Emittery();
+	const eventFixture = {foo: true};
+	const abortController = new AbortController();
+
+	emitter.onAny((eventName, data) => {
+		t.is(eventName, '🦄');
+		t.deepEqual(data, eventFixture);
+	}, {signal: abortController.signal});
+
+	await emitter.emit('🦄', eventFixture);
+	await emitter.emitSerial('🦄', eventFixture);
+	abortController.abort();
+	await emitter.emit('🦄', eventFixture);
 });
 
 test.serial('anyEvent()', async t => {


### PR DESCRIPTION
Fixes #116 

References:

Web API：https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#signal
Mobx：https://mobx.js.org/reactions.html#signal