### PR TITLE
Add support for filter predicate in once() (#122)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -460,9 +460,9 @@ export default class Emittery<
 		eventName: Name | readonly Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): void;
+
 	/**
-	Subscribe to one or more events only once. It will be unsubscribed after the first
-	event that matches the predicate (if provided).
+	Subscribe to one or more events only once. It will be unsubscribed after the first event that matches the predicate (if provided).
 
 	@param eventName - The event name(s) to subscribe to.
 	@param predicate - Optional predicate function to filter event data. The event will only be emitted if the predicate returns true.

--- a/index.d.ts
+++ b/index.d.ts
@@ -460,12 +460,14 @@ export default class Emittery<
 		eventName: Name | readonly Name[],
 		listener: (eventData: AllEventData[Name]) => void | Promise<void>
 	): void;
-
 	/**
 	Subscribe to one or more events only once. It will be unsubscribed after the first
-	event.
+	event that matches the predicate (if provided).
 
-	@returns The promise of event data when `eventName` is emitted. This promise is extended with an `off` method.
+	@param eventName - The event name(s) to subscribe to.
+	@param predicate - Optional predicate function to filter event data. The event will only be emitted if the predicate returns true.
+
+	@returns The promise of event data when `eventName` is emitted and predicate matches (if provided). This promise is extended with an `off` method.
 
 	@example
 	```
@@ -482,11 +484,19 @@ export default class Emittery<
 		console.log(data);
 	});
 
+	// With predicate
+	emitter.once('data', data => data.ok === true).then(data => {
+		console.log(data);
+		//=> {ok: true, value: 42}
+	});
+
 	emitter.emit('🦄', '🌈'); // Logs `🌈` twice
 	emitter.emit('🐶', '🍖'); // Nothing happens
+	emitter.emit('data', {ok: false}); // Nothing happens
+	emitter.emit('data', {ok: true, value: 42}); // Logs {ok: true, value: 42}
 	```
 	*/
-	once<Name extends keyof AllEventData>(eventName: Name | readonly Name[]): EmitteryOncePromise<AllEventData[Name]>;
+	once<Name extends keyof AllEventData>(eventName: Name | readonly Name[], predicate?: (eventData: AllEventData[Name]) => boolean): EmitteryOncePromise<AllEventData[Name]>;
 
 	/**
 	Trigger an event asynchronously, optionally with some data. Listeners are called in the order they were added, but executed concurrently.

--- a/index.js
+++ b/index.js
@@ -334,11 +334,19 @@ export default class Emittery {
 		}
 	}
 
-	once(eventNames) {
+	once(eventNames, predicate) {
+		if (predicate !== undefined && typeof predicate !== 'function') {
+			throw new TypeError('predicate must be a function');
+		}
+
 		let off_;
 
 		const promise = new Promise(resolve => {
 			off_ = this.on(eventNames, data => {
+				if (predicate && !predicate(data)) {
+					return;
+				}
+
 				off_();
 				resolve(data);
 			});

--- a/readme.md
+++ b/readme.md
@@ -297,11 +297,11 @@ await emitter.emit('🦊', 'c'); // Nothing happens
 
 ##### listener(data)
 
-#### once(eventName | eventName[])
+#### once(eventName | eventName[], predicate?)
 
-Subscribe to one or more events only once. It will be unsubscribed after the first event.
+Subscribe to one or more events only once. It will be unsubscribed after the first event that matches the predicate (if provided).
 
-Returns a promise for the event data when `eventName` is emitted. This promise is extended with an `off` method.
+Returns a promise for the event data when `eventName` is emitted and predicate matches (if provided). This promise is extended with an `off` method.
 
 ```js
 import Emittery from 'emittery';
@@ -317,8 +317,16 @@ emitter.once(['🦄', '🐶']).then(data => {
 	console.log(data);
 });
 
+// With predicate
+emitter.once('data', data => data.ok === true).then(data => {
+	console.log(data);
+	//=> {ok: true, value: 42}
+});
+
 emitter.emit('🦄', '🌈'); // Log => '🌈' x2
 emitter.emit('🐶', '🍖'); // Nothing happens
+emitter.emit('data', {ok: false}); // Nothing happens
+emitter.emit('data', {ok: true, value: 42}); // Log => {ok: true, value: 42}
 ```
 
 #### events(eventName)


### PR DESCRIPTION
Add support for filter predicate in once()

This change extends `once(eventNames, predicate)` so you can pass an optional filter function. When provided, `once` will:

• ignore any events for which `predicate(data)` returns false  
• unsubscribe and resolve on the first event where `predicate(data)` returns true  

If no predicate is passed, `once` behaves exactly as before. The predicate is validated up-front and will throw a `TypeError` if it’s not a function. Four new tests cover:

• resolving only on the first matching event  
• throwing on invalid predicate types 
• using multiple event names  
• unsubscribing via `promise.off()` before a match  

Closes #122